### PR TITLE
Fixnginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -101,6 +101,8 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            
+            add_header Access-Control-Allow-Origin *;
         }
     }
 }


### PR DESCRIPTION
Access to fetch at 'https://ota.maa.plus/MaaAssistantArknights/api/announcements/copilot.md' from origin 'https://prts.plus' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.