### PR TITLE
ci: Refactor the entire workflow

### DIFF
--- a/.github/AnnAngela/.eslintrc.yaml
+++ b/.github/AnnAngela/.eslintrc.yaml
@@ -1,0 +1,91 @@
+env:
+  node: true
+  es6: true
+  es2020: true
+  es2021: true
+  es2022: true
+
+parserOptions:
+  ecmaVersion: latest
+  sourceType: module
+
+extends: eslint:recommended
+
+ignorePatterns:
+  - dist/
+
+rules:
+  logical-assignment-operators: error
+  no-new-func: error
+  no-new-object: error
+  no-new-wrappers: error
+  no-var: error
+  prefer-const: error
+  no-extra-parens: error
+  no-misleading-character-class: error
+  no-template-curly-in-string: error
+  require-atomic-updates: error
+  curly: error
+  indent:
+    - 2
+    - 4
+    - SwitchCase: 1
+  linebreak-style:
+    - 0
+    - windows
+  semi:
+    - error
+    - always
+  no-console:
+    - 0
+  no-unused-vars:
+    - 1
+    - varsIgnorePattern: ^_
+  no-redeclare:
+    - 1
+  no-unreachable:
+    - 1
+  no-inner-declarations:
+    - 0
+  comma-dangle:
+    - 1
+    - always-multiline
+  eqeqeq: error
+  dot-notation: error
+  no-else-return: error
+  no-extra-bind: error
+  no-labels: error
+  no-floating-decimal: error
+  no-lone-blocks: error
+  no-loop-func: error
+  no-magic-numbers: off
+  no-multi-spaces: error
+  no-param-reassign: error
+  strict:
+    - error
+    - global
+  quotes:
+    - 1
+    - double
+    - avoidEscape: true
+  quote-props:
+    - 1
+    - as-needed
+    - keywords: true
+      unnecessary: true
+      numbers: false
+  no-empty:
+    - error
+    - allowEmptyCatch: true
+  arrow-spacing:
+    - error
+    - before: true
+      after: true
+  prefer-arrow-callback: error
+  prefer-spread: error
+  prefer-template: error
+  prefer-rest-params: error
+  prefer-exponentiation-operator: error
+  require-await: error
+  arrow-parens: error
+  no-use-before-define: error

--- a/.github/AnnAngela/prepare.js
+++ b/.github/AnnAngela/prepare.js
@@ -1,11 +1,9 @@
 import console from "./console.js";
 import fs from "fs";
 import path from "path";
-import timerPromises from "timers/promises";
 import readDir from "./readDir.js";
 console.info("Copy upload-dir to the temp dir of runner...");
 const tempUploadDirPath = path.join(process.env.RUNNER_TEMP, "upload-dir");
-await fs.promises.cp("upload-dir", tempUploadDirPath, { recursive: true });
 console.info("Remove unnecessary files...");
 const uploadDir = await readDir(tempUploadDirPath);
 const unnecessaryFiles = [];

--- a/.github/workflows/release-mirrors.yml
+++ b/.github/workflows/release-mirrors.yml
@@ -1,52 +1,71 @@
 name: release-mirrors
 
 on:
+  release:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag (defaults to the tag of the release event)"
+        description: Release tag (defaults to the tag of the release event)
         required: false
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
-  get-files:
-    runs-on: "ubuntu-latest"
+  getReleaseTag:
+    name: Get release tag
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Fetch release info
+        id: fetchReleaseInfo
+        if: ${{ !inputs.release_tag }}
+        run: |
+          gh release list --repo 'MaaAssistantArknights/MaaRelease' --limit 10 | tee ${{ runner.temp }}/release_maa
+          head -n 1 ${{ runner.temp }}/release_maa | awk '{ print $1 }' > ${{ runner.temp }}/config
+
+          echo "config:"
+          cat ${{ runner.temp }}/config
+
+          echo "release_tag=$(head -n 1 ${{ runner.temp }}/config)" >> $GITHUB_OUTPUT
+    outputs:
+      release_tag: ${{ inputs.release_tag || steps.fetchReleaseInfo.outputs.release_tag }}
+
+  mirror0:
+    name: Upload to mirror 0
+    runs-on: ubuntu-latest
+    needs: getReleaseTag
+    # Disable it
+    if: 1 == 0 && github.repository == 'MaaAssistantArknights/MaaRelease'
+    steps:
+      - name: Download release files
+        run: |
+          mkdir -pv ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Start to download release files..."
+          gh release download ${{ needs.getReleaseTag.outputs.release_tag }} --repo 'MaaAssistantArknights/MaaRelease' --clobber --dir ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Done."
+      - name: Upload to mirror 0
+        uses: appleboy/scp-action@master
         with:
-          path: MaaRelease
-      - name: "Fetch release info"
-        run: |
-          if [ -n "${{ inputs.release_tag }}" ]; then
-            echo "release_tag=${{ inputs.release_tag }}" >> $GITHUB_ENV
-          else
-            gh release list --repo 'MaaAssistantArknights/MaaRelease' --limit 10 | tee ${{ runner.temp }}/release_maa
-            head -n 1 ${{ runner.temp }}/release_maa | awk '{ print $1 }' > ${{ runner.temp }}/config
+          host: ${{ secrets.SSH_MIRROR_0_HOST }}
+          username: ${{ secrets.SSH_MIRROR_0_USER }}
+          key: ${{ secrets.SSH_MIRROR_0_KEY }}
+          source: ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          target: /data/html/MaaAssistantArknights/MaaRelease/releases/download
+          strip_components: 1
 
-            echo "config:"
-            cat ${{ runner.temp }}/config
-
-            echo "release_tag=$(head -n 1 ${{ runner.temp }}/config)" >> $GITHUB_ENV
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Download release"
+  R2:
+    name: Upload to R2
+    runs-on: ubuntu-latest
+    needs: getReleaseTag
+    if: github.repository == 'MaaAssistantArknights/MaaRelease'
+    steps:
+      - name: Download release files
         run: |
-          mkdir -pv upload-dir/${{ env.release_tag }}
-          cd upload-dir/${{ env.release_tag }}
-          gh release download ${{ env.release_tag }} --repo 'MaaAssistantArknights/MaaRelease' --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: "Upload to mirror 0"
-  #       uses: appleboy/scp-action@master
-  #       with:
-  #         host: ${{ secrets.SSH_MIRROR_0_HOST }}
-  #         username: ${{ secrets.SSH_MIRROR_0_USER }}
-  #         key: ${{ secrets.SSH_MIRROR_0_KEY }}
-  #         source: "upload-dir/${{ env.release_tag }}"
-  #         target: "/data/html/MaaAssistantArknights/MaaRelease/releases/download"
-  #         strip_components: 1
-      - name: "Upload to R2"
-        if: github.repository == 'MaaAssistantArknights/MaaRelease'
+          mkdir -pv ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Start to download release files..."
+          gh release download ${{ needs.getReleaseTag.outputs.release_tag }} --repo 'MaaAssistantArknights/MaaRelease' --clobber --dir ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Done."
+      - name: Upload to R2
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks
@@ -54,39 +73,60 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: us-east-1
           AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
-          SOURCE_DIR: "upload-dir"
-          DEST_DIR: "MaaAssistantArknights/MaaRelease/releases/download"
+          SOURCE_DIR: ${{ runner.temp }}/upload-dir
+          DEST_DIR: MaaAssistantArknights/MaaRelease/releases/download
 
-      - name: Use Node.js
-        if: (github.repository == 'MaaAssistantArknights/MaaRelease' || github.repository == 'AnnAngela/MaaRelease') && !contains(env.release_tag, '.g')
+  AnnAngelaCOS:
+    name: Upload to AnnAngela's COS and fire webhook
+    runs-on: ubuntu-latest
+    needs: getReleaseTag
+    if: (github.repository == 'MaaAssistantArknights/MaaRelease' || github.repository == 'AnnAngela/MaaRelease') && !contains(needs.getReleaseTag.outputs.release_tag, '.g')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         id: setup-node
         with:
           node-version: lts/*
           check-latest: true
           # cache: npm
-      - name: "Upload to AnnAngela's COS and fire webhook"
-        if: (github.repository == 'MaaAssistantArknights/MaaRelease' || github.repository == 'AnnAngela/MaaRelease') && !contains(env.release_tag, '.g')
+      - name: Download release files
+        run: |
+          mkdir -pv ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Start to download release files..."
+          gh release download ${{ needs.getReleaseTag.outputs.release_tag }} --repo 'MaaAssistantArknights/MaaRelease' --clobber --dir ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Done."
+      - name: Upload to AnnAngela's COS and fire webhook
         run: |
           echo "Installing coscli..."
           gh release download --pattern coscli-linux --dir ${{ runner.temp }}/coscli --clobber --repo tencentyun/coscli
           chmod +x ${{ runner.temp }}/coscli/coscli-linux
           echo "coscli installed."
           touch ~/.cos.yaml
-          node MaaRelease/.github/AnnAngela/prepare.js
+          node .github/AnnAngela/prepare.js
           echo "::group::coscli output"
-          ${{ runner.temp }}/coscli/coscli-linux sync ${{ runner.temp }}/upload-dir/${{ env.release_tag }} cos://${{ secrets.ANNANGELA_COS_BUCKET }}/MaaRelease --recursive -e cos.accelerate.myqcloud.com -i ${{ secrets.ANNANGELA_COS_SECRET_ID }} -k ${{ secrets.ANNANGELA_COS_SECRET_KEY }}
+          ${{ runner.temp }}/coscli/coscli-linux sync ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }} cos://${{ secrets.ANNANGELA_COS_BUCKET }}/MaaRelease --recursive -e cos.accelerate.myqcloud.com -i ${{ secrets.ANNANGELA_COS_SECRET_ID }} -k ${{ secrets.ANNANGELA_COS_SECRET_KEY }}
           echo "::endgroup::"
-          node MaaRelease/.github/AnnAngela/webhook.js
+          node .github/AnnAngela/webhook.js
         env:
           WEBHOOK_URL: https://webhook.annangela.cn/custom?from=MaaRelease
           WEBHOOK_SECRET: ${{ secrets.ANNANGELA_WEBHOOK_SECRET }}
-          GH_TOKEN: ${{ github.token }}
 
-      - name: "Upload to MAA S3"
-        if: github.repository == 'MaaAssistantArknights/MaaRelease'
+  MAA_S3:
+    name: Upload to MAA S3
+    runs-on: ubuntu-latest
+    needs: getReleaseTag
+    if: github.repository == 'MaaAssistantArknights/MaaRelease'
+    steps:
+      - name: Download release files
+        run: |
+          mkdir -pv ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Start to download release files..."
+          gh release download ${{ needs.getReleaseTag.outputs.release_tag }} --repo 'MaaAssistantArknights/MaaRelease' --clobber --dir ${{ runner.temp }}/upload-dir/${{ needs.getReleaseTag.outputs.release_tag }}
+          echo "Done."
+      - name: Upload to MAA S3
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks
@@ -94,7 +134,19 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.MAA_MINIO_RELEASE_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MAA_MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MAA_MINIO_SECRET_KEY }}
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: us-east-1
           AWS_S3_ENDPOINT: ${{ secrets.MAA_MINIO_ENDPOINT }}
-          SOURCE_DIR: "upload-dir"
-          DEST_DIR: "MaaAssistantArknights/MaaRelease/releases/download"
+          SOURCE_DIR: ${{ runner.temp }}/upload-dir
+          DEST_DIR: MaaAssistantArknights/MaaRelease/releases/download
+
+  updateVersionApi:
+    name: Dispatch the "update_version_api" workflow
+    runs-on: ubuntu-latest
+    needs:
+      - mirror0
+      - R2
+      - AnnAngelaCOS
+      - MAA_S3
+    steps:
+      - name: Dispatch the "update_version_api" workflow
+        run: gh workflow run update_version_api --repo ${{ github.repository }}

--- a/.github/workflows/update_version_api.yml
+++ b/.github/workflows/update_version_api.yml
@@ -2,7 +2,6 @@ name: update_version_api
 
 on:
   workflow_dispatch:
-  release:
 
 jobs:
   update_version_api:


### PR DESCRIPTION
重构了一下gha：
1. 现在上传文件到各个镜像是并行的了，可以有效利用 runner 的上传带宽（关于每个镜像都要下载一次文件，我测试过了，不论是走 cache 还是 artifact，都没有直接下载来得快）；
2. release 触发流程从直接触发 update_version_api 改为先触发 release-mirrors 再触发 update_version_api，这样就可以等镜像部署完成后再更新 version api，避免用户更新时镜像还没准备好。

大佬们看看有啥问题吗（如果觉得 S3 太久，也可以把 `jobs.updateVersionApi.needs` 里的 `MAA_S3` 注释掉）