### PR TITLE
fix: OperBoxNameOCR for EN

### DIFF
--- a/MaaAssistantArknights/api/resource/global/YoStarEN/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/YoStarEN/resource/tasks.json
@@ -19,5 +19,13 @@
         "text": [
             "Volsinii"
         ]
+    },
+    "OperBoxNameOCR": {
+        "specialParams": [
+            160,
+            4,
+            7,
+            0
+        ]
     }
 }


### PR DESCRIPTION
Long name operators such as Nine-Colored Deer, Lava the Purgatory, Specter the Unchained may not get detected.
Changed [2] parameter from 6 to 7.
With 7 operators detected correctly.

@ABA2396 So this is my first try with the MaaRelease. is this how it should be?
Just a small change to a parameter, nothing much.