### PR TITLE
fix: 修正繁中服 "風雪過境復刻-雪山大典" 的 roi

### DIFF
--- a/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
@@ -60,10 +60,10 @@
         ],
         "preDelay": 1000,
         "roi": [
-            1043,
-            423,
-            195,
-            133
+            999,
+            243,
+            281,
+            176
         ],
         "next": [
             "ChapterSwipeToTheRight"


### PR DESCRIPTION
突然發現怎麼都識別不到 "雪山大典"，都會識別到下面的 "謝拉格旅行指南"...

MAA本體的 task.json 裡是對的，是這裡的 roi 位置寫錯了 🫠🫠🫠