### PR TITLE
Revert "perf: api to follow main release"

### DIFF
--- a/MaaAssistantArknights/api/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/tasks.json
@@ -28,6 +28,22 @@
     },
     "IS-Open": {
         "action": "ClickSelf",
+        "roi": [
+            77,
+            64,
+            396,
+            437
+        ],
+        "sub": [
+            "EnterChapterIS"
+        ],
+        "next": [
+            "SideStoryStage",
+            "SwipeToStageIS"
+        ]
+    },
+    "IS-OpenOcr": {
+        "action": "ClickSelf",
         "algorithm": "OcrDetect",
         "roi": [
             0,


### PR DESCRIPTION
Reverts MaaAssistantArknights/MaaRelease#59

@Constrat I don't know why, but according to @zzyyyl and @ABA2396  feedback there may be some problems, and they will give new fixes later. As an online issue, I rolled back these changes first.