### PR TITLE
fix: macOS R2 DMG

### DIFF
--- a/.github/downloadReleaseFiles/action.yaml
+++ b/.github/downloadReleaseFiles/action.yaml
@@ -71,7 +71,7 @@ runs:
                 export PATTERN="$PATTERN --pattern *-macos-universal.dmg"
             fi
             if [ "$OS" = "macos-ota" ]; then
-                export PATTERN="$PATTERN --pattern *.delta --pattern appcast.xml"
+                export PATTERN="$PATTERN --pattern *-macos-universal.dmg --pattern *.delta --pattern appcast.xml"
             fi
             if [ "$OS" = "macos-runtime" ]; then
                 export PATTERN="$PATTERN --pattern *-macos-runtime-universal.zip"


### PR DESCRIPTION
Sparkle 从 R2 下载更新时，如果找不到增量包会 fallback 到完整 DMG 文件。因此上传时也应该将 DMG 包括进来。