### PR TITLE
chore: 繁中服_周年月卡領取 &「揭幕者們」活動導航

### DIFF
--- a/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
@@ -1,6 +1,12 @@
 {
+    "SpecialAccessActivities": {
+        "text": ["周年", "專享", "活動", "月卡", "推薦"]
+    },
+    "SpecialAccessActivitiesConfirm": {
+        "text": ["立即", "立即領取"]
+    },
     "PV-OpenOcr": {
-        "text": ["揭幕者們", "揭幕", "者們"]
+        "text": ["揭幕者們", "揭幕", "者們", "彩車", "遊行", "荒蕪", "之舞"]
     },
     "PVChapterToPV": {
         "text": ["四幕匯演", "四幕", "匯演"]


### PR DESCRIPTION
補上周年月卡領取

跟

「揭幕者們」活動後面開放的階段名稱 (彩車遊行、荒蕪之舞)