### PR TITLE
chore: 繁中服「次生方案」小遊戲

### DIFF
--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -297,23 +297,23 @@
     },
     "miniGame": [
       {
-        "MinimumRequired": "v6.2.2",
-        "DisplayKey": "MiniGame@AT@ConversationRoom",
-        "Display": "墟：相談室·御影",
-        "Value": "MiniGame@AT@ConversationRoom",
-        "TipKey": "MiniGame@AT@ConversationRoomTip",
-        "UtcStartTime": "2026/02/26 16:00:00",
-        "UtcExpireTime": "2026/03/19 03:59:59",
+        "MinimumRequired": "v6.4.0",
+        "DisplayKey": "MiniGame@RM-TR-1",
+        "Display": "次生方案 RM-TR-1",
+        "Value": "MiniGame@RM-TR-1@Begin",
+        "TipKey": "MiniGame@RM-TR-1Tip",
+        "UtcStartTime": "2026/04/08 16:00:00",
+        "UtcExpireTime": "2026/04/29 03:59:59",
         "TimeZone": 8
       },
       {
-        "MinimumRequired": "v6.2.2",
-        "DisplayKey": "MiniGame@ALL@HoneyFruit",
-        "Display": "爭鋒頻道：蜜果城",
-        "Value": "MiniGame@ALL@GreenGrass@HoneyFruit@Begin",
-        "TipKey": "MiniGame@ALL@GreenGrassTip",
-        "UtcStartTime": "2026/03/13 16:00:00",
-        "UtcExpireTime": "2026/03/27 03:59:59",
+        "MinimumRequired": "v6.4.0",
+        "DisplayKey": "MiniGame@RM-1",
+        "Display": "次生方案 RM-1",
+        "Value": "MiniGame@RM-1@Begin",
+        "TipKey": "MiniGame@RM-1Tip",
+        "UtcStartTime": "2026/04/08 16:00:00",
+        "UtcExpireTime": "2026/04/29 03:59:59",
         "TimeZone": 8
       }
     ]

--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -297,7 +297,7 @@
     },
     "miniGame": [
       {
-        "MinimumRequired": "v6.4.0",
+        "MinimumRequired": "v6.7.2",
         "DisplayKey": "MiniGame@RM-TR-1",
         "Display": "次生方案 RM-TR-1",
         "Value": "MiniGame@RM-TR-1@Begin",
@@ -307,7 +307,7 @@
         "TimeZone": 8
       },
       {
-        "MinimumRequired": "v6.4.0",
+        "MinimumRequired": "v6.7.2",
         "DisplayKey": "MiniGame@RM-1",
         "Display": "次生方案 RM-1",
         "Value": "MiniGame@RM-1@Begin",


### PR DESCRIPTION
等 https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/16216 合併了 & 發版了
再合這個比較好

~~以免又有人問為什麼小遊戲執行不了!!!!~~

## Summary by Sourcery

新功能：
- 在 StageActivityV2 中为“次生方案”小游戏的繁体中文服务器版本新增配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add configuration for the Traditional Chinese server version of the "次生方案" mini-game in StageActivityV2.

</details>