### PR TITLE
chore: 繁中服「揭幕者們」復刻

### DIFF
--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -283,21 +283,21 @@
   },
   "txwy": {
     "sideStoryStage": {
-      "出蒼白海 復刻": {
+      "揭幕者們 復刻": {
         "MinimumRequired": "v6.0.1",
         "Activity": {
-          "Tip": "SideStory「出蒼白海」復刻",
-          "StageName": "出蒼白海 復刻",
-          "UtcStartTime": "2026/05/13 16:00:00",
-          "UtcExpireTime": "2026/05/23 03:59:59",
+          "Tip": "SideStory「揭幕者們」復刻",
+          "StageName": "揭幕者們 復刻",
+          "UtcStartTime": "2026/05/27 04:00:00",
+          "UtcExpireTime": "2026/06/06 03:59:59",
           "TimeZone": 8
         },
         "Stages": [
-          { "Display": "SSReopen-EP", "Value": "SSReopen-EP", "Drop": "代理1~8" },
-          { "Display": "EP-8", "Value": "EP-8", "Drop": "30093" },
-          { "Display": "EP-7", "Value": "EP-7", "Drop": "30053" },
-          { "Display": "EP-6", "Value": "EP-6", "Drop": "30023" },
-          { "Display": "EP-4", "Value": "EP-4", "Drop": "搓玉用" }
+          { "Display": "SSReopen-PV", "Value": "SSReopen-PV", "Drop": "代理1~10" },
+          { "Display": "PV-10", "Value": "PV-10", "Drop": "31053" },
+          { "Display": "PV-9", "Value": "PV-9", "Drop": "30103" },
+          { "Display": "PV-8", "Value": "PV-8", "Drop": "30083" },
+          { "Display": "PV-5", "Value": "PV-5", "Drop": "搓玉用" }
         ]
       },
       "無憂夢囈": {


### PR DESCRIPTION
## Summary by Sourcery

改進內容：
- 調整活動關卡配置資料，以反映繁體中文版客戶端中「揭幕者們」活動的復刻舉辦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust activity stage configuration data to reflect the rerun of the 「揭幕者們」 event for the Traditional Chinese client.

</details>