### PR TITLE
chore: 繁中服「雪山降臨1101」活動導航 & 「喀蘭貿易技術研發部」小遊戲

### DIFF
--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -328,12 +328,12 @@
     "miniGame": [
       {
         "MinimumRequired": "v6.9.4",
-        "DisplayKey": "MiniGame@PV",
-        "Display": "PV-煙花籌委會",
-        "Value": "MiniGame@PV@Begin",
-        "TipKey": "MiniGame@PVTip",
-        "UtcStartTime": "2026/05/27 04:00:00",
-        "UtcExpireTime": "2026/06/06 03:59:59",
+        "DisplayKey": "MiniGame@OS",
+        "Display": "喀蘭貿易技術研發部",
+        "Value": "MiniGame@OS@Begin",
+        "TipKey": "MiniGame@OSTip",
+        "UtcStartTime": "2026/06/10 16:00:00",
+        "UtcExpireTime": "2026/07/01 03:59:59",
         "TimeZone": 8
       }
     ]

--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -301,20 +301,20 @@
           { "Display": "PV-5", "Value": "PV-5", "Drop": "搓玉用" }
         ]
       },
-      "無憂夢囈": {
+      "雪山降臨1101": {
         "MinimumRequired": "v6.0.1",
         "Activity": {
-          "Tip": "SideStory「無憂夢囈」",
-          "StageName": "無憂夢囈",
-          "UtcStartTime": "2026/04/01 16:00:00",
-          "UtcExpireTime": "2026/04/15 03:59:59",
+          "Tip": "SideStory「雪山降臨1101」",
+          "StageName": "雪山降臨1101",
+          "UtcStartTime": "2026/06/10 16:00:00",
+          "UtcExpireTime": "2026/07/01 03:59:59",
           "TimeZone": 8
         },
         "Stages": [
-          { "Display": "AveMujica-8", "Value": "AveMujica-8", "Drop": "31073" },
-          { "Display": "AveMujica-7", "Value": "AveMujica-7", "Drop": "31063" },
-          { "Display": "AveMujica-6", "Value": "AveMujica-6", "Drop": "30033" },
-          { "Display": "AveMujica-5", "Value": "AveMujica-5", "Drop": "搓玉用" }
+          { "Display": "OS-9", "Value": "OS-9", "Drop": "31053" },
+          { "Display": "OS-8", "Value": "OS-8", "Drop": "30103" },
+          { "Display": "OS-7", "Value": "OS-7", "Drop": "30023" },
+          { "Display": "OS-4", "Value": "OS-4", "Drop": "搓玉用" }
         ]
       }
     },

--- a/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
@@ -5,6 +5,9 @@
     "OSChapterToOS": {
         "text": ["聖巡", "之旅"]
     },
+	"MiniGame@OS@CheckPointsUsed": {
+        "text": ["所有點數", "結束本回合"]
+    },
     "EnterEpisodeNew": {
         "baseTask": "#none",
         "Doc": "base_task",

--- a/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
@@ -1,9 +1,9 @@
 {
-    "AveMujica-OpenOcr": {
-        "text": ["無", "憂", "夢", "囈"]
+    "OS-OpenOcr": {
+        "text": ["雪山", "降臨", "變革", "之路", "喀蘭", "之心"]
     },
-    "AveMujicaChapterToAveMujica": {
-        "text": ["萬", "般", "皆", "夢"]
+    "OSChapterToOS": {
+        "text": ["聖巡", "之旅"]
     },
     "EnterEpisodeNew": {
         "baseTask": "#none",


### PR DESCRIPTION
## 由 Sourcery 撰写的摘要

为繁体中文伺服器的「雪山降臨 1101」活動導航新增設定，並更新相關任務／資源定義。

新功能：
- 為繁體中文伺服器的「雪山降臨 1101」活動新增關卡活動配置。

增強內容：
- 更新繁體中文伺服器的任務／資源對應，以支援新的活動導航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration for the Traditional Chinese server "Snow Mountain Advent 1101" event navigation and update related task/resource definitions.

New Features:
- Introduce stage activity configuration for the "Snow Mountain Advent 1101" event in the Traditional Chinese server.

Enhancements:
- Update task/resource mappings for the Traditional Chinese server to support the new event navigation.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 撰写的摘要

为繁体中文伺服器的「雪山降臨 1101」活動導航新增設定，並更新相關任務／資源定義。

新功能：
- 為繁體中文伺服器的「雪山降臨 1101」活動新增關卡活動配置。

增強內容：
- 更新繁體中文伺服器的任務／資源對應，以支援新的活動導航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration for the Traditional Chinese server "Snow Mountain Advent 1101" event navigation and update related task/resource definitions.

New Features:
- Introduce stage activity configuration for the "Snow Mountain Advent 1101" event in the Traditional Chinese server.

Enhancements:
- Update task/resource mappings for the Traditional Chinese server to support the new event navigation.

</details>

</details>