### PR TITLE
chore: 繁中服「未許之地」

### DIFF
--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -298,20 +298,20 @@
           { "Display": "PV-5", "Value": "PV-5", "Drop": "搓玉用" }
         ]
       },
-      "雪山降臨1101": {
+      "未許之地": {
         "MinimumRequired": "v6.0.1",
         "Activity": {
-          "Tip": "SideStory「雪山降臨1101」",
-          "StageName": "雪山降臨1101",
-          "UtcStartTime": "2026/06/10 16:00:00",
-          "UtcExpireTime": "2026/07/01 03:59:59",
+          "Tip": "SideStory「未許之地」",
+          "StageName": "未許之地",
+          "UtcStartTime": "2026/07/06 16:00:00",
+          "UtcExpireTime": "2026/07/20 03:59:59",
           "TimeZone": 8
         },
         "Stages": [
-          { "Display": "OS-9", "Value": "OS-9", "Drop": "31053" },
-          { "Display": "OS-8", "Value": "OS-8", "Drop": "30103" },
-          { "Display": "OS-7", "Value": "OS-7", "Drop": "30023" },
-          { "Display": "OS-4", "Value": "OS-4", "Drop": "搓玉用" }
+          { "Display": "UR-8", "Value": "UR-8", "Drop": "31033" },
+          { "Display": "UR-7", "Value": "UR-7", "Drop": "31023" },
+          { "Display": "UR-6", "Value": "UR-6", "Drop": "30033" },
+          { "Display": "UR-5", "Value": "UR-5", "Drop": "搓玉用" }
         ]
       }
     },

--- a/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
@@ -1,14 +1,9 @@
 {
-    "CF-Open": {
+    "UR-OpenOcr": { 
+        "text": ["未許", "之地", "天空", "生活", "展會", "逃離哥", "倫比亞"]
     },
-    "OS-OpenOcr": {
-        "text": ["雪山", "降臨", "變革", "之路", "喀蘭", "之心"]
-    },
-    "OSChapterToOS": {
-        "text": ["聖巡", "之旅"]
-    },
-	"MiniGame@OS@CheckPointsUsed": {
-        "text": ["所有點數", "結束本回合"]
+    "URChapterToUR": {
+        "text": ["天空", "生活", "展會"]
     },
     "EnterEpisodeNew": {
         "baseTask": "#none",


### PR DESCRIPTION
## Summary by Sourcery

更新「未許之地」活動的繁體中文伺服器變體之活動與任務設定檔，使 GUI 關卡資料與資源任務與新的區域配置保持一致。

New Features:
- 在繁體中文用戶端 GUI 中新增「未許之地」活動關卡的設定。
- 為繁體中文伺服器新增或調整與「未許之地」活動相關的任務／資源定義。

Enhancements:
- 更新現有的活動與任務 JSON 資料，以支援繁體中文伺服器的區域差異。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update activity and task configuration files for the Traditional Chinese server variant of the "未許之地" event, aligning GUI stage data and resource tasks with the new regional setup.

New Features:
- Add configuration for the "未許之地" event stages in the Traditional Chinese client GUI.
- Introduce or adjust task/resource definitions for the Traditional Chinese server related to the "未許之地" activity.

Enhancements:
- Refresh existing activity and task JSON data to support regional differences for the Traditional Chinese server.

</details>