### PR TITLE
chore: 繁中服「雅賽努斯復仇記」活動導航

### DIFF
--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -312,7 +312,8 @@
         "Stages": [
           { "Display": "ME-8", "Value": "ME-8", "Drop": "31093" },
           { "Display": "ME-7", "Value": "ME-7", "Drop": "30043" },
-          { "Display": "ME-6", "Value": "ME-6", "Drop": "30013" }
+          { "Display": "ME-6", "Value": "ME-6", "Drop": "30013" },
+          { "Display": "ME-5", "Value": "ME-5", "Drop": "搓玉用" }
         ]
       }
     },

--- a/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
@@ -1,14 +1,8 @@
 {
-    "UR-OpenOcr": { 
-        "text": ["未許", "之地", "天空", "生活", "展會", "逃離哥", "倫比亞"]
+    "ME-OpenOcr": {
+        "text": ["雅賽", "努斯", "復仇記", "街頭", "戲劇"]
     },
-    "URChapterToUR": {
-        "text": ["天空", "生活", "展會"]
-    },
-    "EnterEpisodeNew": {
-        "baseTask": "#none",
-        "Doc": "base_task",
-        "template": "empty.png",
-        "action": "ClickSelf"
+    "MEChapterToME": {
+        "text": ["神殿", "儀式"]
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

添加配置更新，以支持繁體中文（txwy）伺服器中「雅賽努斯復仇記」活動的關卡導覽。

New Features:
- 在 StageActivityV2 GUI 配置中，為「雅賽努斯復仇記」活動新增關卡導覽條目。
- 為 txwy 繁體中文伺服器新增相應的任務定義，以便自動化處理此新活動。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration updates to support the "雅賽努斯復仇記" event navigation for the Traditional Chinese (txwy) server.

New Features:
- Introduce new stage navigation entries for the "雅賽努斯復仇記" activity in the StageActivityV2 GUI configuration.
- Add corresponding task definitions for the txwy Traditional Chinese server to enable automated handling of the new event.

</details>