### PR TITLE
chore: 牛杂的黑流树海刷钱 钱满了就不继续刷了 改成满了也能接着刷鹿师傅的经验和肉鸽等级

### DIFF
--- a/MaaAssistantArknights/api/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/tasks.json
@@ -220,7 +220,7 @@
         "next": ["BlackFlowTemporary@InvestConfirmLoop", "#self"]
     },
     "BlackFlowTemporary@InvestConfirmLoop": {
-        "doc": "识别 <确认投资> 并点击；同位置出现 <源石锭不足> 或出现 <投资受限> 均结束循环，若出现 <已达上限> 则结束任务",
+        "doc": "识别 <确认投资> 并点击；同位置出现 <源石锭不足> 或出现 <投资受限> 或出现 <已达上限>均结束循环",
         "algorithm": "OcrDetect",
         "action": "ClickSelf",
         "text": ["确认投资"],
@@ -244,12 +244,12 @@
         "next": ["BlackFlowTemporary@ExitThenAbandon", "#self"]
     },
     "BlackFlowTemporary@InvestMax": {
-        "doc": "识别到 <已达上限> 即结束任务",
+        "doc": "识别到 <已达上限> 结束投资循环并放弃本次探索",
         "algorithm": "OcrDetect",
         "action": "DoNothing",
         "text": ["已达上限"],
         "roi": [1150, 95, 120, 45],
-        "next": ["Stop"]
+        "next": ["BlackFlowTemporary@ExitThenAbandon", "#self"]
     },
     "BlackFlowTemporary@ExitThenAbandon": {
         "doc": "模板匹配退出按钮并点击",


### PR DESCRIPTION
close issue https://github.com/MaaAssistantArknights/MaaRelease/issues/603

找了一圈只找到这里 如果在别的仓库我可以把pr挪过去= =

## Summary by Sourcery

允许在游戏内货币已达上限的情况下，**牛杂的黑流树海**任务仍可继续运行，以便获得经验值和肉鸽等级提升，从而解决关联问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow the 牛杂的黑流树海 task to continue running for experience and roguelike level gains even when the in-game currency is already capped, addressing the linked issue.

</details>