### PR TITLE
feat: 优化加群页

### DIFF
--- a/.github/workflows/update_qq_group_index.yml
+++ b/.github/workflows/update_qq_group_index.yml
@@ -1,10 +1,13 @@
 name: update_qq_group_index
 
+# Windows：与以往相同，人工指定推荐群编号（0 = Windows 推 QQ 频道）
+# Android / Mac：生成时自动选群（查询 groupinfo，优先空位多的；失败则第一个可用群）
+
 on:
   workflow_dispatch:
     inputs:
       group_number:
-        description: '群编号（输入 0 表示 QQ 频道模式）'
+        description: 'Windows 群编号（输入 0 表示 Windows 使用 QQ 频道；Android/Mac 始终自动选群）'
         required: true
 
 jobs:
@@ -22,6 +25,9 @@ jobs:
 
       - name: Generate index.html
         working-directory: MaaAssistantArknights/api/qqgroup
+        env:
+          # 自动选 Android/Mac 推荐群时用的人数接口
+          GROUPINFO_API: https://join.maameow.com/api/groupinfo
         run: |
           if [ "${{ github.event.inputs.group_number }}" = "0" ]; then
             python gen_index.py channel
@@ -36,8 +42,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add index.html
           if [ "${{ github.event.inputs.group_number }}" = "0" ]; then
-            git commit -m "Update index.html to QQ channel" || echo "No changes to commit"
+            git commit -m "Update index.html: Windows QQ channel; Android/Mac auto" || echo "No changes to commit"
           else
-            git commit -m "Update index.html to group ${{ github.event.inputs.group_number }}" || echo "No changes to commit"
+            git commit -m "Update index.html to Windows group ${{ github.event.inputs.group_number }} (Android/Mac auto)" || echo "No changes to commit"
           fi
           git push

--- a/.github/workflows/update_qq_group_index.yml
+++ b/.github/workflows/update_qq_group_index.yml
@@ -1,14 +1,38 @@
 name: update_qq_group_index
 
-# Windows：与以往相同，人工指定推荐群编号（0 = Windows 推 QQ 频道）
-# Android / Mac：生成时自动选群（查询 groupinfo，优先空位多的；失败则第一个可用群）
+# 按平台更新加群页推荐：
+#   - platform 默认 windows（最常见）
+#   - mode=auto：粘性自动（未满保持，满了选第一个有空位）
+#   - mode=manual：用 group_number 钉死该平台推荐群
+#   - mode=channel：该平台推 QQ 频道（无配置则回退 auto）
+#   - 未选中的平台：保持 index.html 里上次推荐，不查人数
 
 on:
   workflow_dispatch:
     inputs:
-      group_number:
-        description: 'Windows 群编号（输入 0 表示 Windows 使用 QQ 频道；Android/Mac 始终自动选群）'
+      platform:
+        description: 操作平台（默认 Windows）
+        type: choice
         required: true
+        default: windows
+        options:
+          - windows
+          - android
+          - mac
+          - all
+      mode:
+        description: 推荐模式
+        type: choice
+        required: true
+        default: auto
+        options:
+          - auto
+          - manual
+          - channel
+      group_number:
+        description: mode=manual 时的群编号（从 1 开始，对应该平台 content 文件行序）
+        required: false
+        default: ""
 
 jobs:
   build:
@@ -21,29 +45,86 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Generate index.html
         working-directory: MaaAssistantArknights/api/qqgroup
         env:
-          # 自动选 Android/Mac 推荐群时用的人数接口
           GROUPINFO_API: https://join.maameow.com/api/groupinfo
+          PLATFORM: ${{ github.event.inputs.platform }}
+          MODE: ${{ github.event.inputs.mode }}
+          GROUP_NUMBER: ${{ github.event.inputs.group_number }}
         run: |
-          if [ "${{ github.event.inputs.group_number }}" = "0" ]; then
-            python gen_index.py channel
-          else
-            python gen_index.py ${{ github.event.inputs.group_number }}
-          fi
+          set -e
+          PLATFORM="$(echo -n "$PLATFORM" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+          MODE="$(echo -n "$MODE" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+          GROUP_NUMBER="$(echo -n "$GROUP_NUMBER" | tr -d '[:space:]')"
+
+          case "$PLATFORM" in
+            windows|android|mac|all) ;;
+            *)
+              echo "invalid platform: $PLATFORM"
+              exit 1
+              ;;
+          esac
+
+          case "$MODE" in
+            auto)
+              python gen_index.py "$PLATFORM" auto
+              ;;
+            channel)
+              python gen_index.py "$PLATFORM" channel
+              ;;
+            manual)
+              if [ -z "$GROUP_NUMBER" ]; then
+                echo "mode=manual 需要填写 group_number"
+                exit 1
+              fi
+              if ! [[ "$GROUP_NUMBER" =~ ^[0-9]+$ ]]; then
+                echo "group_number 必须是数字: $GROUP_NUMBER"
+                exit 1
+              fi
+              if [ "$PLATFORM" = "all" ]; then
+                echo "mode=manual 不能选 platform=all，请指定 windows/android/mac"
+                exit 1
+              fi
+              python gen_index.py "$PLATFORM" "$GROUP_NUMBER"
+              ;;
+            *)
+              echo "invalid mode: $MODE"
+              exit 1
+              ;;
+          esac
 
       - name: Commit and push
         working-directory: MaaAssistantArknights/api/qqgroup
+        env:
+          PLATFORM: ${{ github.event.inputs.platform }}
+          MODE: ${{ github.event.inputs.mode }}
+          GROUP_NUMBER: ${{ github.event.inputs.group_number }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add index.html
-          if [ "${{ github.event.inputs.group_number }}" = "0" ]; then
-            git commit -m "Update index.html: Windows QQ channel; Android/Mac auto" || echo "No changes to commit"
-          else
-            git commit -m "Update index.html to Windows group ${{ github.event.inputs.group_number }} (Android/Mac auto)" || echo "No changes to commit"
-          fi
+
+          PLATFORM="$(echo -n "$PLATFORM" | tr -d '[:space:]')"
+          MODE="$(echo -n "$MODE" | tr -d '[:space:]')"
+          GROUP_NUMBER="$(echo -n "$GROUP_NUMBER" | tr -d '[:space:]')"
+
+          case "$MODE" in
+            auto)
+              MSG="Update index.html: sticky auto (${PLATFORM})"
+              ;;
+            channel)
+              MSG="Update index.html: QQ channel (${PLATFORM})"
+              ;;
+            manual)
+              MSG="Update index.html: ${PLATFORM} group ${GROUP_NUMBER} (manual)"
+              ;;
+            *)
+              MSG="Update index.html (${PLATFORM}/${MODE})"
+              ;;
+          esac
+
+          git commit -m "$MSG" || echo "No changes to commit"
           git push

--- a/MaaAssistantArknights/api/qqgroup/content_android.txt
+++ b/MaaAssistantArknights/api/qqgroup/content_android.txt
@@ -1,0 +1,3 @@
+https://qm.qq.com/q/L8Tyfs268E|安卓版MAA 交流1群|1074855131
+https://qm.qq.com/q/hWvDx6cNag|安卓版MAA 交流2群|1092878305
+https://qm.qq.com/q/ptPGw0wcEw|安卓版MAA 交流3群|764534097

--- a/MaaAssistantArknights/api/qqgroup/content_channels.txt
+++ b/MaaAssistantArknights/api/qqgroup/content_channels.txt
@@ -1,0 +1,4 @@
+# 格式: 平台|频道链接|频道名称
+# 平台: windows / android / mac（没有频道的平台可不写）
+windows|https://pd.qq.com/s/8d3h265zd?b=9|MAA QQ 频道
+android|https://pd.qq.com/s/4w4kgi4s4|安卓版 MAA QQ 频道

--- a/MaaAssistantArknights/api/qqgroup/content_mac.txt
+++ b/MaaAssistantArknights/api/qqgroup/content_mac.txt
@@ -1,0 +1,1 @@
+https://qm.qq.com/q/2uhPXiNOR0|Mac版MAA 交流群|1091086083

--- a/MaaAssistantArknights/api/qqgroup/content_windows.txt
+++ b/MaaAssistantArknights/api/qqgroup/content_windows.txt
@@ -33,7 +33,3 @@ https://qm.qq.com/q/pt47DXsH2E|MAA 三十二裙|216314927
 https://qm.qq.com/q/ZsMmM5IX2A|MAA 三十三裙|1003478193
 https://qm.qq.com/q/ImsUweGc8i|MAA 三十四裙|1009052305
 https://qm.qq.com/q/hfisRrMmnC|MAA 三十五裙|774683898
-https://qm.qq.com/q/L8Tyfs268E|安卓版MAA 交流1群|1074855131
-https://qm.qq.com/q/hWvDx6cNag|安卓版MAA 交流2群|1092878305
-https://qm.qq.com/q/ptPGw0wcEw|安卓版MAA 交流3群|764534097
-https://qm.qq.com/q/2uhPXiNOR0|Mac版MAA 交流群|1091086083

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -1,66 +1,263 @@
+import json
 import sys
+from pathlib import Path
 
 # 使用：
-#   python gen_index.py 26       - 生成群模式页面（推荐第26群）
-#   python gen_index.py channel  - 生成频道模式页面
+#   python gen_index.py                          - 各平台默认推荐第 1 群
+#   python gen_index.py 28 2 1                   - Windows/Android/Mac 推荐群编号
+#   python gen_index.py windows 28 android 2 mac 1
+#   python gen_index.py channel                  - 有频道的平台推荐频道，否则仍推荐群
+#
+# 运营配置：
+#   content_windows.txt / content_android.txt / content_mac.txt
+#     每行: 加群链接|群名称|群号
+#   content_channels.txt
+#     每行: 平台|频道链接|频道名称   （# 开头为注释）
 
-# QQ 频道信息
-qq_channel_url = "https://pd.qq.com/s/8d3h265zd?b=9"
-qq_channel_name = "MAA QQ 频道"
+CHANNELS_FILE = "content_channels.txt"
 
-with open("content_summary.txt", "r", encoding="utf-8") as f:
-    lines = [line.strip() for line in f if line.strip()]
+PLATFORMS = ("windows", "android", "mac")
+PLATFORM_FILES = {
+    "windows": "content_windows.txt",
+    "android": "content_android.txt",
+    "mac": "content_mac.txt",
+}
+PLATFORM_LABELS = {
+    "windows": "Windows",
+    "android": "Android",
+    "mac": "Mac",
+}
+# 兼容别名
+PLATFORM_ALIASES = {
+    "win": "windows",
+    "windows": "windows",
+    "android": "android",
+    "mac": "mac",
+    "macos": "mac",
+}
 
-# 解析参数：channel 为频道模式，数字为群模式
-arg = sys.argv[1] if len(sys.argv) > 1 else "1"
-is_channel_mode = arg.lower() == "channel"
 
-if is_channel_mode:
-    # 频道模式：推荐跳转到 QQ 频道
-    url = qq_channel_url
-    name = qq_channel_name
-    gid = ""
-    group_index = -1  # 无当前推荐群
-else:
-    # 群模式：推荐跳转到指定群
-    group_index = int(arg) - 1
-    if group_index < 0 or group_index >= len(lines):
-        raise ValueError("群编号超出范围")
-    url, name, gid = lines[group_index].split("|")
+def load_groups(path: Path) -> list[dict]:
+    if not path.is_file():
+        raise FileNotFoundError(f"找不到群配置文件: {path}")
+    groups = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("|")
+            if len(parts) < 3:
+                raise ValueError(f"配置行格式错误 ({path.name}): {line!r}")
+            url, name, gid = parts[0], parts[1], parts[2]
+            groups.append(
+                {
+                    "url": url,
+                    "name": name,
+                    "gid": gid,
+                    "active": url.startswith("http"),
+                }
+            )
+    return groups
 
-groups_list_html = ""
-valid_groups_count = 0
 
-# QQ 频道条目（频道模式下标记为当前推荐）
-if is_channel_mode:
-    qq_channel_html = f'<li class="channel"><strong><span class="current">{qq_channel_name} - 当前推荐</span></strong></li>\n'
-else:
-    qq_channel_html = f'<li class="channel"><a href="{qq_channel_url}" onclick="handleLinkClick(event)">{qq_channel_name}</a></li>\n'
+def load_channels(path: Path) -> dict[str, dict]:
+    """返回 platform -> {url, name}。文件不存在则空 dict。"""
+    channels: dict[str, dict] = {}
+    if not path.is_file():
+        return channels
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("|")
+            if len(parts) < 3:
+                raise ValueError(f"频道配置行格式错误 ({path.name}): {line!r}")
+            platform_raw, url, name = parts[0].strip().lower(), parts[1].strip(), parts[2].strip()
+            platform = PLATFORM_ALIASES.get(platform_raw)
+            if not platform:
+                raise ValueError(
+                    f"未知平台 {platform_raw!r}，应为: {', '.join(PLATFORMS)}"
+                )
+            if not url.startswith("http"):
+                raise ValueError(f"频道链接无效: {url!r}")
+            channels[platform] = {"url": url, "name": name}
+    return channels
 
-for i, line in enumerate(lines):
-    parts = line.split("|")
-    if len(parts) < 3:
-        continue  # 跳过格式不正确的行
-        
-    u, n, g = parts
-    if u.startswith('http'):
-        valid_groups_count += 1
-        if i == group_index:
-            groups_list_html += f'<li><strong><span class="current">{n} ({g}) - 当前推荐</span></strong></li>\n'
+
+def parse_args(argv: list[str]) -> tuple[dict[str, int], bool]:
+    """返回 (各平台 1-based 推荐编号, 是否频道模式)。"""
+    recommends = {p: 1 for p in PLATFORMS}
+    is_channel = False
+
+    if not argv:
+        return recommends, False
+
+    if len(argv) == 1 and argv[0].lower() == "channel":
+        return recommends, True
+
+    # 位置参数：windows android mac 编号
+    if all(a.isdigit() for a in argv) and 1 <= len(argv) <= 3:
+        for i, p in enumerate(PLATFORMS[: len(argv)]):
+            recommends[p] = int(argv[i])
+        return recommends, False
+
+    # 关键字参数：windows 28 android 2 mac 1 [channel]
+    i = 0
+    while i < len(argv):
+        token = argv[i].lower()
+        if token == "channel":
+            is_channel = True
+            i += 1
+            continue
+        if token in PLATFORM_ALIASES:
+            if i + 1 >= len(argv) or not argv[i + 1].isdigit():
+                raise SystemExit(f"需要为 {token} 指定群编号，例如: {token} 1")
+            recommends[PLATFORM_ALIASES[token]] = int(argv[i + 1])
+            i += 2
+            continue
+        raise SystemExit(
+            "用法:\n"
+            "  python gen_index.py [win编号] [android编号] [mac编号]\n"
+            "  python gen_index.py windows 28 android 2 mac 1\n"
+            "  python gen_index.py channel"
+        )
+
+    return recommends, is_channel
+
+
+def pick_recommend(groups: list[dict], index_1based: int, platform: str) -> dict:
+    idx = index_1based - 1
+    if idx < 0 or idx >= len(groups):
+        raise ValueError(
+            f"{PLATFORM_LABELS[platform]} 推荐群编号超出范围: "
+            f"{index_1based}（共 {len(groups)} 个）"
+        )
+    return groups[idx]
+
+
+def main() -> None:
+    base = Path(__file__).resolve().parent
+    recommends, is_channel_mode = parse_args(sys.argv[1:])
+    channels = load_channels(base / CHANNELS_FILE)
+
+    platforms_data: dict[str, dict] = {}
+    for platform in PLATFORMS:
+        groups = load_groups(base / PLATFORM_FILES[platform])
+        rec = pick_recommend(groups, recommends[platform], platform)
+        ch = channels.get(platform)
+        # 频道模式且该平台有频道 → 推荐频道；否则推荐群
+        use_channel = is_channel_mode and ch is not None
+        if use_channel:
+            recommend = {"url": ch["url"], "name": ch["name"], "gid": "", "kind": "channel"}
         else:
-            groups_list_html += f'<li><a href="{u}" onclick="handleLinkClick(event)">{n} ({g})</a></li>\n'
-    else:
-        # 不合规 → 灰色禁用显示
-        groups_list_html += f'<li><span class="disabled">{n} ({g})</span></li>\n'
+            recommend = {
+                "url": rec["url"],
+                "name": rec["name"],
+                "gid": rec["gid"],
+                "kind": "group",
+            }
+        platforms_data[platform] = {
+            "label": PLATFORM_LABELS[platform],
+            "recommendIndex": recommends[platform] - 1,
+            "recommend": recommend,
+            "groups": groups,
+            "validCount": sum(1 for g in groups if g["active"]),
+            "channel": ch,
+        }
 
-index_html = f"""
-<!DOCTYPE html>
-<html>
+    def esc(s: str) -> str:
+        return (
+            s.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+        )
+
+    def render_group_items(platform: str) -> str:
+        data = platforms_data[platform]
+        items = []
+        for i, g in enumerate(data["groups"]):
+            name, gid, url = g["name"], g["gid"], g["url"]
+            label = f"{esc(name)} ({esc(gid)})"
+            # 仅「群推荐」时才标 data-recommend；选平台后由 JS 高亮
+            is_rec = data["recommend"]["kind"] == "group" and i == data["recommendIndex"]
+            rec_attr = ' data-recommend="1"' if is_rec else ""
+            if not g["active"]:
+                items.append(
+                    f'<li class="group-item" data-platform="{platform}" '
+                    f'data-label="{label}"{rec_attr}>'
+                    f'<span class="disabled">{label}</span></li>'
+                )
+            else:
+                items.append(
+                    f'<li class="group-item" data-platform="{platform}" '
+                    f'data-label="{label}" data-href="{esc(url)}"{rec_attr}>'
+                    f'<a href="{esc(url)}" onclick="handleLinkClick(event)">{label}</a></li>'
+                )
+        return "\n".join(items)
+
+    groups_sections_html = ""
+    for platform in PLATFORMS:
+        data = platforms_data[platform]
+        groups_sections_html += f"""
+        <section class="group-section" id="section-{platform}" data-platform="{platform}">
+            <h3 class="group-section-title">{esc(data["label"])} 群组
+                <span class="group-count">共 {data["validCount"]} 个</span>
+            </h3>
+            <ul class="group-list">
+                {render_group_items(platform)}
+            </ul>
+        </section>
+"""
+
+    # 频道：按平台渲染，默认隐藏，选平台后只显示对应项
+    channel_items_html = ""
+    for platform in PLATFORMS:
+        ch = channels.get(platform)
+        if not ch:
+            continue
+        label = esc(ch["name"])
+        url = esc(ch["url"])
+        is_ch_rec = platforms_data[platform]["recommend"]["kind"] == "channel"
+        rec_attr = ' data-recommend="1"' if is_ch_rec else ""
+        channel_items_html += (
+            f'<li class="channel channel-item" data-platform="{platform}" '
+            f'data-label="{label}" data-href="{url}"{rec_attr}>'
+            f'<a href="{url}" onclick="handleLinkClick(event)">{label}</a></li>\n'
+        )
+
+    header_extra = " channel-header" if is_channel_mode else ""
+
+    # JS 用的推荐映射（平台 → 跳转目标）
+    recommend_map = {
+        p: {
+            "url": platforms_data[p]["recommend"]["url"],
+            "name": platforms_data[p]["recommend"]["name"],
+            "gid": platforms_data[p]["recommend"]["gid"],
+            "kind": platforms_data[p]["recommend"]["kind"],
+        }
+        for p in PLATFORMS
+    }
+    recommend_json = json.dumps(recommend_map, ensure_ascii=False)
+    # 各平台是否有频道（前端切换展示用）
+    channels_meta = {
+        p: ({"url": ch["url"], "name": ch["name"]} if (ch := channels.get(p)) else None)
+        for p in PLATFORMS
+    }
+    channels_json = json.dumps(channels_meta, ensure_ascii=False)
+    has_any_channel = bool(channels)
+    channel_block_display = "" if has_any_channel else " style=\"display:none\""
+
+    index_html = f"""<!DOCTYPE html>
+<html lang="zh-CN">
 <head>
-    <title>欢迎加入 {name}</title>
+    <title>欢迎加入 MAA 交流群</title>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        body {{ font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; }}
+        body {{ font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; color: #222; }}
         .current {{ color: #ff6600; }}
         ul {{ list-style-type: none; padding: 0; }}
         li {{ margin: 12px 0; padding: 8px; background: #f9f9f9; border-radius: 5px; }}
@@ -69,16 +266,172 @@ index_html = f"""
         li > a:hover {{ color: #004499; }}
         .container {{ max-width: 800px; margin: 0 auto; }}
         .header {{ background: #eef5ff; padding: 20px; border-radius: 8px; margin-bottom: 20px; }}
-        .primary-link {{ display: inline-block; padding: 10px 20px; background: #0066cc; color: white; border-radius: 5px; margin: 10px 0; }}
-        .primary-link:hover {{ background: #004499; text-decoration: none; }}
-        .cancel-btn {{ 
-            display: inline-block; 
-            padding: 8px 16px; 
-            background: #ff6666; 
-            color: white; 
-            border: none; 
-            border-radius: 5px; 
-            cursor: pointer; 
+        .header.channel-header {{ background: linear-gradient(135deg, #e8f0fe, #f0e6ff); }}
+        .platform-row {{
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin: 12px 0 4px;
+        }}
+        .platform-label {{ color: #555; font-size: 0.95em; margin-right: 4px; }}
+        .platform-tabs {{
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }}
+        .platform-tab {{
+            padding: 8px 16px;
+            border: 2px solid #c5d8f5;
+            border-radius: 999px;
+            background: #fff;
+            color: #0066cc;
+            font-weight: bold;
+            font-size: 0.95em;
+            cursor: pointer;
+            transition: border-color .15s, background .15s, color .15s;
+        }}
+        .platform-tab:hover {{
+            border-color: #0066cc;
+            background: #f3f8ff;
+        }}
+        .platform-tab.active {{
+            border-color: #0066cc;
+            background: #0066cc;
+            color: #fff;
+        }}
+        .header.channel-header .platform-tab.active {{
+            border-color: #7c4dff;
+            background: #7c4dff;
+        }}
+        .primary-link {{
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 12px 22px;
+            min-height: 44px;
+            background: #0066cc;
+            color: #fff;
+            border-radius: 8px;
+            margin: 10px 0;
+            border: none;
+            cursor: pointer;
+            font-size: 1em;
+            font-weight: bold;
+            text-decoration: none;
+            overflow: hidden;
+            isolation: isolate;
+            z-index: 0;
+            box-shadow: 0 4px 12px rgba(0, 102, 204, 0.28);
+            -webkit-tap-highlight-color: transparent;
+            touch-action: manipulation;
+        }}
+        .primary-link .btn-text {{
+            position: relative;
+            z-index: 2;
+        }}
+        .primary-link.is-disabled {{
+            pointer-events: none;
+            cursor: not-allowed;
+            box-shadow: none;
+            opacity: 0.55;
+            background: #8aa8cc;
+        }}
+        .primary-link.is-disabled.chroma {{
+            background: #8aa8cc;
+        }}
+        .primary-link.is-disabled.chroma::before,
+        .primary-link.is-disabled.chroma::after {{
+            display: none;
+        }}
+        /* 无缝炫彩：色带重复两份，translateX 平移 50% 避免顿挫 */
+        .primary-link.chroma:not(.is-disabled) {{
+            background: transparent;
+        }}
+        .primary-link.chroma:not(.is-disabled)::before {{
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 200%;
+            z-index: 0;
+            background: linear-gradient(
+                90deg,
+                #ff4d4f, #fa8c16, #fadb14, #52c41a, #13c2c2, #1677ff, #722ed1, #eb2f96,
+                #ff4d4f, #fa8c16, #fadb14, #52c41a, #13c2c2, #1677ff, #722ed1, #eb2f96,
+                #ff4d4f
+            );
+            animation: chroma-slide 3s linear infinite;
+            pointer-events: none;
+            will-change: transform;
+        }}
+        .primary-link.chroma:not(.is-disabled)::after {{
+            content: "";
+            position: absolute;
+            top: 0;
+            left: -40%;
+            width: 40%;
+            height: 100%;
+            z-index: 1;
+            background: linear-gradient(
+                100deg,
+                transparent 0%,
+                rgba(255, 255, 255, 0.15) 40%,
+                rgba(255, 255, 255, 0.45) 50%,
+                rgba(255, 255, 255, 0.15) 60%,
+                transparent 100%
+            );
+            animation: chroma-shine 2.5s linear infinite;
+            pointer-events: none;
+            will-change: transform;
+        }}
+        .primary-link.chroma:not(.is-disabled):hover {{
+            filter: brightness(1.05);
+            box-shadow: 0 6px 16px rgba(114, 46, 209, 0.35);
+            text-decoration: none;
+            color: #fff;
+        }}
+        .primary-link.chroma:not(.is-disabled):active {{
+            filter: brightness(0.98);
+        }}
+        @keyframes chroma-slide {{
+            from {{ transform: translateX(0); }}
+            to {{ transform: translateX(-50%); }}
+        }}
+        @keyframes chroma-shine {{
+            from {{ transform: translateX(0); }}
+            to {{ transform: translateX(350%); }}
+        }}
+        @media (prefers-reduced-motion: reduce) {{
+            .primary-link.chroma:not(.is-disabled)::before,
+            .primary-link.chroma:not(.is-disabled)::after {{
+                animation: none;
+            }}
+            .primary-link.chroma:not(.is-disabled)::before {{
+                width: 100%;
+                background: #0066cc;
+                transform: none;
+            }}
+            .primary-link.chroma:not(.is-disabled)::after {{
+                display: none;
+            }}
+            .primary-link.chroma:not(.is-disabled) {{
+                box-shadow: none;
+            }}
+            .channel-header .primary-link.chroma:not(.is-disabled)::before {{
+                background: #7c4dff;
+            }}
+        }}
+        .cancel-btn {{
+            display: inline-block;
+            padding: 8px 16px;
+            background: #ff6666;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
             margin-left: 10px;
         }}
         .cancel-btn:hover {{ background: #cc5555; }}
@@ -87,80 +440,296 @@ index_html = f"""
         .channel {{ background: linear-gradient(135deg, #e8f0fe, #f0e6ff); border-left: 4px solid #7c4dff; }}
         .channel a {{ color: #7c4dff; }}
         .channel a:hover {{ color: #5e35b1; }}
-        .channel-header {{ background: linear-gradient(135deg, #e8f0fe, #f0e6ff); }}
-        .channel-header .primary-link {{ background: #7c4dff; }}
-        .channel-header .primary-link:hover {{ background: #5e35b1; }}
+        .channel-item {{ display: none; }}
+        .channel-item.is-active {{ display: list-item; }}
+        .channel-item.is-recommend {{
+            background: #f3e8ff;
+            border-left: 4px solid #7c4dff;
+        }}
+        .tip {{ color: #666; font-size: 0.95em; }}
+        .hint {{ color: #555; margin: 8px 0 0; }}
+        /* 下方群列表：按平台分块，默认隐藏，选中后只显示对应平台 */
+        .group-section {{
+            display: none;
+            margin: 18px 0 24px;
+            padding: 14px 16px 8px;
+            border: 1px solid #e3eaf5;
+            border-radius: 10px;
+            background: #fafcff;
+        }}
+        .group-section.is-active {{
+            display: block;
+            border-color: #0066cc;
+            box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.12);
+            background: #f3f8ff;
+        }}
+        .group-section-title {{
+            margin: 0 0 10px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid #e3eaf5;
+            font-size: 1.1em;
+        }}
+        .group-count {{
+            color: #888;
+            font-weight: normal;
+            font-size: 0.9em;
+            margin-left: 6px;
+        }}
+        .group-list {{ margin: 0; }}
+        .group-item.is-recommend {{
+            background: #fff4e8;
+            border-left: 4px solid #ff6600;
+        }}
+        .lists-heading {{ margin: 24px 0 8px; font-size: 1.15em; }}
+        .lists-placeholder {{ color: #888; margin: 12px 0 24px; }}
+        .lists-placeholder.is-hidden {{ display: none; }}
+        .channel-placeholder {{ color: #888; margin: 8px 0; }}
+        .channel-placeholder.is-hidden {{ display: none; }}
+        .channel-block.is-empty .channel-list {{ display: none; }}
     </style>
     <script>
-        let redirectEnabled = true;
+        const RECOMMENDS = {recommend_json};
+        const CHANNELS = {channels_json};
+        const PLATFORM_LABELS = {{ windows: "Windows", android: "Android", mac: "Mac" }};
+
+        // 必须用户主动选择平台后，才启动自动跳转
+        let redirectEnabled = false;
         let countdown = 8;
         let countdownTimer = null;
-        
-        function cancelRedirect() {{
+        let currentJoinUrl = "";
+        let currentPlatform = "";
+        let userCancelled = false;
+
+        function stopCountdown() {{
             redirectEnabled = false;
             if (countdownTimer) {{
                 clearTimeout(countdownTimer);
+                countdownTimer = null;
             }}
-            document.getElementById('countdown').textContent = '0';
-            document.getElementById('redirectText').innerHTML = '自动跳转已取消';
-            document.getElementById('cancelBtn').style.display = 'none';
         }}
-        
+
+        function cancelRedirect() {{
+            userCancelled = true;
+            stopCountdown();
+            const text = document.getElementById("redirectText");
+            if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+        }}
+
         function handleLinkClick(event) {{
-            cancelRedirect();
-            // 允许正常跳转
+            // 点了列表里的群：取消自动跳转，但保留已选平台与主按钮
+            if (currentPlatform) cancelRedirect();
         }}
-        
+
         function handlePrimaryLinkClick(event) {{
+            const primary = document.getElementById("primaryLink");
+            if (primary.classList.contains("is-disabled") || !currentJoinUrl) {{
+                event.preventDefault();
+                return;
+            }}
             cancelRedirect();
-            // 允许正常跳转
         }}
-        
+
+        function startRedirect(url) {{
+            if (userCancelled) {{
+                // 用户已取消过：只更新链接，不再自动跳
+                currentJoinUrl = url;
+                const text = document.getElementById("redirectText");
+                if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+                return;
+            }}
+            currentJoinUrl = url;
+            redirectEnabled = true;
+            countdown = 8;
+            if (countdownTimer) clearTimeout(countdownTimer);
+
+            document.getElementById("redirectText").innerHTML =
+                '已选择平台，页面将在 <span id="countdown">' + countdown + '</span> 秒后自动跳转……' +
+                '<button type="button" id="cancelBtn" class="cancel-btn" onclick="cancelRedirect()">取消自动跳转</button>';
+            countdownTimer = setTimeout(updateCountdown, 1000);
+        }}
+
         function updateCountdown() {{
             if (redirectEnabled && countdown > 0) {{
                 countdown--;
-                document.getElementById('countdown').textContent = countdown;
+                const el = document.getElementById("countdown");
+                if (el) el.textContent = countdown;
                 countdownTimer = setTimeout(updateCountdown, 1000);
             }} else if (redirectEnabled && countdown === 0) {{
-                window.location.href = "{url}";
+                window.location.href = currentJoinUrl;
             }}
         }}
-        
-        window.onload = function() {{
-            updateCountdown();
-        }};
+
+        function resetListRecommendMarks(selector) {{
+            document.querySelectorAll(selector).forEach((li) => {{
+                li.classList.remove("is-recommend");
+                if (li.querySelector(".disabled")) return;
+                const href = li.getAttribute("data-href");
+                const label = li.getAttribute("data-label") || "";
+                if (!href) return;
+                li.innerHTML = '<a href="' + href + '" onclick="handleLinkClick(event)">' +
+                    label + "</a>";
+            }});
+        }}
+
+        function applyRecommendMark(li) {{
+            li.classList.add("is-recommend");
+            const label = li.getAttribute("data-label") || "";
+            li.innerHTML = '<strong><span class="current">' + label +
+                " - 当前推荐</span></strong>";
+        }}
+
+        function markPlatformRecommend(platform) {{
+            resetListRecommendMarks(".group-item");
+            resetListRecommendMarks(".channel-item");
+
+            const listsPlaceholder = document.getElementById("listsPlaceholder");
+            if (listsPlaceholder) listsPlaceholder.classList.add("is-hidden");
+
+            document.querySelectorAll(".group-section").forEach((sec) => {{
+                sec.classList.toggle("is-active", sec.getAttribute("data-platform") === platform);
+            }});
+
+            // 频道：只展示当前平台
+            const channelPlaceholder = document.getElementById("channelPlaceholder");
+            const channelBlock = document.getElementById("channelBlock");
+            let hasChannel = false;
+            document.querySelectorAll(".channel-item").forEach((li) => {{
+                const match = li.getAttribute("data-platform") === platform;
+                li.classList.toggle("is-active", match);
+                if (match) hasChannel = true;
+            }});
+            if (channelPlaceholder) {{
+                channelPlaceholder.classList.toggle("is-hidden", hasChannel);
+                if (!hasChannel) {{
+                    channelPlaceholder.textContent = "该平台暂无 QQ 频道";
+                }}
+            }}
+            if (channelBlock) {{
+                channelBlock.classList.toggle("is-empty", !hasChannel);
+            }}
+
+            // 高亮当前推荐（群或频道）
+            document.querySelectorAll(
+                '.group-item[data-platform="' + platform + '"][data-recommend="1"]'
+            ).forEach(applyRecommendMark);
+            document.querySelectorAll(
+                '.channel-item[data-platform="' + platform + '"][data-recommend="1"]'
+            ).forEach(applyRecommendMark);
+        }}
+
+        function selectPlatform(platform) {{
+            const rec = RECOMMENDS[platform];
+            if (!rec) return;
+
+            // 主动点选平台视为新意图：重新开启自动跳转
+            userCancelled = false;
+            currentPlatform = platform;
+
+            document.querySelectorAll(".platform-tab").forEach((btn) => {{
+                btn.classList.toggle("active", btn.getAttribute("data-platform") === platform);
+            }});
+
+            markPlatformRecommend(platform);
+
+            const title = document.getElementById("join-title");
+            const gidEl = document.getElementById("join-gid");
+            const primary = document.getElementById("primaryLink");
+            const btnText = primary.querySelector(".btn-text");
+            const label = PLATFORM_LABELS[platform] || platform;
+            const isChannel = rec.kind === "channel";
+
+            if (isChannel) {{
+                title.textContent = "欢迎加入【" + rec.name + "】（" + label + "）";
+                gidEl.style.display = "none";
+                if (btnText) btnText.textContent = "立即加入 QQ 频道";
+            }} else {{
+                title.textContent = "欢迎加入【" + rec.name + "】（" + label + "）";
+                if (rec.gid) {{
+                    gidEl.style.display = "";
+                    gidEl.innerHTML = '群号: <strong>' + rec.gid + "</strong>";
+                }} else {{
+                    gidEl.style.display = "none";
+                }}
+                if (btnText) btnText.textContent = "立即加入当前推荐群组";
+            }}
+
+            primary.href = rec.url;
+            primary.classList.remove("is-disabled");
+            primary.setAttribute("aria-disabled", "false");
+            startRedirect(rec.url);
+        }}
     </script>
 </head>
 <body>
     <div class="container">
-        <div class="header{' channel-header' if is_channel_mode else ''}">
-            <h2>欢迎加入【{name}】</h2>
-            {'<p>群号: <strong>' + gid + '</strong></p>' if gid else ''}
-            <p><a href="{url}" class="primary-link" onclick="handlePrimaryLinkClick(event)">{'立即加入 QQ 频道' if is_channel_mode else '立即加入当前推荐群组'}</a></p>
-            <p id="redirectText">
-                页面将在 <span id="countdown">8</span> 秒后自动跳转……
-                <button id="cancelBtn" class="cancel-btn" onclick="cancelRedirect()">取消自动跳转</button>
+        <div id="join-header" class="header{header_extra}">
+            <h2 id="join-title">欢迎加入 MAA 交流群</h2>
+            <p id="join-gid" style="display:none"></p>
+
+            <div class="platform-row">
+                <span class="platform-label">请先选择平台：</span>
+                <div class="platform-tabs" role="tablist" aria-label="客户端平台">
+                    <button type="button" class="platform-tab" data-platform="windows"
+                        onclick="selectPlatform('windows')">Windows</button>
+                    <button type="button" class="platform-tab" data-platform="android"
+                        onclick="selectPlatform('android')">Android</button>
+                    <button type="button" class="platform-tab" data-platform="mac"
+                        onclick="selectPlatform('mac')">Mac</button>
+                </div>
+            </div>
+            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。</p>
+
+            <p>
+                <a id="primaryLink" href="#" class="primary-link chroma is-disabled"
+                   aria-disabled="true" onclick="handlePrimaryLinkClick(event)">
+                    <span class="btn-text">请先选择平台</span>
+                </a>
             </p>
+            <p id="redirectText">尚未选择平台，不会自动跳转</p>
         </div>
-        
-        <h3>QQ 频道:</h3>
-        <ul>
-            {qq_channel_html}
-        </ul>
-        
-        <h3>可用群组列表 (共 {valid_groups_count} 个):</h3>
-        <ul>
-            {groups_list_html}
-        </ul>
-        
-        <p class="tip">如果当前群组已满或链接失效，请选择其他群组加入（点击任意链接将取消自动跳转）</p>
+
+        <div id="channelBlock" class="channel-block"{channel_block_display}>
+            <h3>QQ 频道</h3>
+            <p id="channelPlaceholder" class="channel-placeholder">请先选择平台，以查看对应频道。</p>
+            <ul class="channel-list">
+{channel_items_html}            </ul>
+        </div>
+
+        <h3 class="lists-heading">群组列表</h3>
+        <p id="listsPlaceholder" class="lists-placeholder">请先在上方选择平台，以查看对应群列表。</p>
+{groups_sections_html}
+        <p class="tip">如果当前群组已满或链接失效，请选择其他群组加入（点击任意链接将取消自动跳转）。</p>
     </div>
 </body>
 </html>
 """
 
-with open("index.html", "w", encoding="utf-8") as f:
-    f.write(index_html)
+    out = base / "index.html"
+    out.write_text(index_html, encoding="utf-8")
 
-mode_str = "频道模式" if is_channel_mode else f"群模式 (推荐: {name})"
-print(f"index.html 已更新为 {mode_str}")
+    # 清理旧的分平台页面
+    for stale in ("index_windows.html", "index_android.html", "index_mac.html"):
+        p = base / stale
+        if p.exists():
+            p.unlink()
+
+    parts = []
+    for p in PLATFORMS:
+        rec = platforms_data[p]["recommend"]
+        kind = "频道" if rec["kind"] == "channel" else f"#{recommends[p]}"
+        parts.append(f"{PLATFORM_LABELS[p]}{kind}({rec['name']})")
+    mode = " / ".join(parts)
+
+    print(f"已更新 {out.name} → {mode}")
+    for p in PLATFORMS:
+        ch = platforms_data[p]["channel"]
+        ch_info = f", 频道 {ch['name']}" if ch else ", 无频道"
+        print(
+            f"  - {PLATFORM_LABELS[p]}: {platforms_data[p]['validCount']} 个群"
+            f", 配置 {PLATFORM_FILES[p]}{ch_info}"
+        )
+    print(f"  - 频道配置: {CHANNELS_FILE} ({len(channels)} 个平台)")
+
+
+if __name__ == "__main__":
+    main()

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -78,6 +78,8 @@ def load_groups(path: Path) -> list[dict]:
                     "active": url.startswith("http"),
                 }
             )
+    if not groups:
+        raise ValueError(f"群配置文件没有任何有效群行: {path.name}")
     return groups
 
 
@@ -686,6 +688,8 @@ def main() -> None:
         for p in PLATFORMS
     }
     channels_json = json.dumps(channels_meta, ensure_ascii=False)
+    # 与生成期 Python 侧同一 GROUPINFO_API（含环境变量覆盖）
+    groupinfo_api_json = json.dumps(GROUPINFO_API)
     has_any_channel = bool(channels)
     channel_block_display = "" if has_any_channel else " style=\"display:none\""
 
@@ -1025,11 +1029,11 @@ def main() -> None:
         const RECOMMENDS = {recommend_json};
         const CHANNELS = {channels_json};
         const PLATFORM_LABELS = {{ windows: "Windows", android: "Android", mac: "Mac" }};
-        // 对外 groupinfo API（头像 + 人数）；失败则不展示
-        const GROUPINFO_API = "https://join.maameow.com/api/groupinfo";
+        // 与 gen_index.py 同一 GROUPINFO_API（可由环境变量覆盖后注入）
+        const GROUPINFO_API = {groupinfo_api_json};
         const groupInfoCache = Object.create(null); // gid -> info | null(failed)
 
-        // 必须用户主动选择平台后，才启动自动跳转
+        // 未选平台不自动跳转；URL/?platform= 指定时等同已选并启动跳转
         let redirectEnabled = false;
         let countdown = 8;
         let countdownTimer = null;
@@ -1513,7 +1517,7 @@ def main() -> None:
 
             <div class="platform-row">
                 <span class="platform-label">请先选择平台：</span>
-                <div class="platform-tabs" role="tablist" aria-label="客户端平台">
+                <div class="platform-tabs" role="group" aria-label="客户端平台">
                     <button type="button" class="platform-tab" data-platform="windows"
                         onclick="selectPlatform('windows')">Windows</button>
                     <button type="button" class="platform-tab" data-platform="android"

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -7,12 +7,19 @@ import urllib.request
 from pathlib import Path
 
 # 使用：
-#   python gen_index.py 28                       - Windows 推荐第 28 群（CI 同款）
-#                                                  Android / Mac 自动选（人数有空位优先）
-#   python gen_index.py channel                  - Windows 推荐 QQ 频道；Android/Mac 仍自动选群
-#   python gen_index.py                          - Windows 默认第 1 群；Android/Mac 自动
-#   python gen_index.py windows 28               - 只指定 Windows
-#   python gen_index.py windows 28 android 2     - 可选：手动覆盖 Android/Mac（调试用）
+#   python gen_index.py                          - 三平台粘性自动
+#   python gen_index.py auto                     - 同上
+#   python gen_index.py windows auto             - 只刷新 Windows（其它平台保持状态，不查人数）
+#   python gen_index.py android 2                - 手动钉 Android 第 2 群
+#   python gen_index.py windows channel          - Windows 推 QQ 频道
+#   python gen_index.py 28                       - 兼容：等同 windows 28
+#   python gen_index.py channel                  - 兼容：等同 windows channel
+#
+# 自动策略（粘性，仅对「本次操作的平台」生效）：
+#   1. 从现有 index.html 的 RECOMMENDS 读取上次推荐群
+#   2. 只查当前推荐是否满员；未满 / 查失败 → 保持
+#   3. 已满 / 已下架 → 按列表顺序选「第一个有空位」的群
+#   4. 写回 index.html（粘性状态就在 RECOMMENDS 里，无额外文件）
 #
 # 运营配置：
 #   content_windows.txt / content_android.txt / content_mac.txt
@@ -26,8 +33,8 @@ CHANNELS_FILE = "content_channels.txt"
 GROUPINFO_API = os.environ.get(
     "GROUPINFO_API", "https://join.maameow.com/api/groupinfo"
 ).rstrip("/")
-# 仅 Windows 由 CI/参数指定推荐；Android、Mac 默认自动
-AUTO_PLATFORMS = frozenset({"android", "mac"})
+# 换群时分批查人数，每批找到有空位的就停
+OCCUPANCY_BATCH = 5
 
 PLATFORMS = ("windows", "android", "mac")
 PLATFORM_FILES = {
@@ -99,68 +106,174 @@ def load_channels(path: Path) -> dict[str, dict]:
     return channels
 
 
-def parse_args(argv: list[str]) -> tuple[dict[str, int | None], bool]:
-    """返回 (各平台 1-based 推荐编号或 None=自动, 是否 Windows 频道模式)。
+def parse_args(argv: list[str]) -> dict:
+    """解析命令行，返回生成计划。
 
-    None 表示该平台用自动选群。CI 只传一个数字时仅设置 Windows。
+    返回 dict:
+      touch: 本次要刷新的平台集合（其它平台 freeze 保持状态、不查人数）
+      mode:  platform -> "auto" | "manual" | "channel" | "freeze"
+      manual: platform -> 1-based 群编号（仅 manual）
     """
-    # Windows 无参时默认第 1 群；Android/Mac 默认自动
-    recommends: dict[str, int | None] = {
-        "windows": 1,
-        "android": None,
-        "mac": None,
-    }
-    is_channel = False
+    usage = (
+        "用法:\n"
+        "  python gen_index.py                         # 三平台粘性自动\n"
+        "  python gen_index.py auto\n"
+        "  python gen_index.py windows auto            # 只刷新 Windows\n"
+        "  python gen_index.py android 2               # 手动钉 Android #2\n"
+        "  python gen_index.py windows channel         # 该平台推 QQ 频道\n"
+        "  python gen_index.py 28                      # 兼容：windows 手动 #28\n"
+        "  python gen_index.py channel                 # 兼容：windows channel"
+    )
+
+    def plan(
+        touch: set[str],
+        *,
+        mode_for_touch: str = "auto",
+        manual: dict[str, int] | None = None,
+        channel_platforms: set[str] | None = None,
+    ) -> dict:
+        modes = {p: "freeze" for p in PLATFORMS}
+        for p in touch:
+            modes[p] = mode_for_touch
+        if channel_platforms:
+            for p in channel_platforms:
+                modes[p] = "channel"
+                touch.add(p)
+        man = manual or {}
+        for p, n in man.items():
+            modes[p] = "manual"
+            touch.add(p)
+        return {"touch": set(touch), "mode": modes, "manual": man}
 
     if not argv:
-        return recommends, False
+        return plan(set(PLATFORMS), mode_for_touch="auto")
+
+    if len(argv) == 1 and argv[0].lower() in ("auto", "sticky"):
+        return plan(set(PLATFORMS), mode_for_touch="auto")
 
     if len(argv) == 1 and argv[0].lower() == "channel":
-        # Windows 走频道；Android/Mac 仍自动选群
-        recommends["windows"] = None
-        return recommends, True
+        return plan({"windows"}, mode_for_touch="channel", channel_platforms={"windows"})
 
-    # 单个数字：兼容旧 CI → 只改 Windows
+    # 单个数字：兼容旧习惯 → 只钉 Windows
     if len(argv) == 1 and argv[0].isdigit():
-        recommends["windows"] = int(argv[0])
-        return recommends, False
+        n = int(argv[0])
+        if n == 0:
+            return plan({"windows"}, mode_for_touch="channel", channel_platforms={"windows"})
+        return plan({"windows"}, mode_for_touch="manual", manual={"windows": n})
 
-    # 多个纯数字：仅第一个作为 Windows（Android/Mac 保持自动，避免误伤）
-    if all(a.isdigit() for a in argv) and 1 <= len(argv) <= 3:
-        recommends["windows"] = int(argv[0])
-        if len(argv) >= 2:
+    # 平台 + 动作：windows auto | android 2 | mac channel
+    if len(argv) == 2:
+        p_raw, action = argv[0].lower(), argv[1].lower()
+        if p_raw in ("all", "every"):
+            platform_set = set(PLATFORMS)
+        elif p_raw in PLATFORM_ALIASES:
+            platform_set = {PLATFORM_ALIASES[p_raw]}
+        else:
+            platform_set = set()
+        if platform_set:
+            if action in ("auto", "sticky"):
+                return plan(platform_set, mode_for_touch="auto")
+            if action == "channel":
+                return plan(platform_set, mode_for_touch="channel", channel_platforms=set(platform_set))
+            if action.isdigit():
+                n = int(action)
+                if n == 0:
+                    return plan(
+                        platform_set,
+                        mode_for_touch="channel",
+                        channel_platforms=set(platform_set),
+                    )
+                if len(platform_set) != 1:
+                    raise SystemExit("手动编号只能针对单个平台，例如: windows 28")
+                only = next(iter(platform_set))
+                return plan(platform_set, mode_for_touch="manual", manual={only: n})
+            raise SystemExit(usage)
+
+    # 关键字多段：windows 28 android auto mac channel
+    if argv:
+        touch: set[str] = set()
+        modes: dict[str, str] = {p: "freeze" for p in PLATFORMS}
+        manual: dict[str, int] = {}
+        i = 0
+        while i < len(argv):
+            token = argv[i].lower()
+            if token in ("auto", "sticky") and i == 0 and len(argv) == 1:
+                return plan(set(PLATFORMS), mode_for_touch="auto")
+            if token in PLATFORM_ALIASES:
+                p = PLATFORM_ALIASES[token]
+                if i + 1 >= len(argv):
+                    raise SystemExit(f"需要为 {token} 指定 auto / channel / 群编号")
+                action = argv[i + 1].lower()
+                touch.add(p)
+                if action in ("auto", "sticky"):
+                    modes[p] = "auto"
+                elif action == "channel":
+                    modes[p] = "channel"
+                elif action.isdigit():
+                    n = int(action)
+                    if n == 0:
+                        modes[p] = "channel"
+                    else:
+                        modes[p] = "manual"
+                        manual[p] = n
+                else:
+                    raise SystemExit(f"未知动作 {action!r}，应为 auto / channel / 数字")
+                i += 2
+                continue
+            if token == "channel":
+                touch.add("windows")
+                modes["windows"] = "channel"
+                i += 1
+                continue
+            raise SystemExit(usage)
+        if touch:
+            return {"touch": touch, "mode": modes, "manual": manual}
+
+    raise SystemExit(usage)
+
+
+def freeze_recommend(
+    groups: list[dict],
+    platform: str,
+    sticky_gid: str | None,
+) -> tuple[dict, int, str]:
+    """未选中的平台：沿用状态，不查人数。"""
+    label = PLATFORM_LABELS[platform]
+    if sticky_gid:
+        idx = index_of_gid(groups, sticky_gid)
+        if idx is not None and groups[idx].get("active"):
+            g = groups[idx]
             print(
-                "提示: 位置参数仅 Windows 生效；"
-                f"已忽略多余参数 {argv[1:]!r}。"
-                "若需手动指定 Android/Mac，请用: android 2 mac 1",
+                f"保持[{label}]: #{idx + 1} {g['name']}（本轮未选中，不查人数）",
                 file=sys.stderr,
             )
-        return recommends, False
-
-    # 关键字参数：windows 28 [android 2] [mac 1] [channel]
-    i = 0
-    while i < len(argv):
-        token = argv[i].lower()
-        if token == "channel":
-            is_channel = True
-            recommends["windows"] = None
-            i += 1
-            continue
-        if token in PLATFORM_ALIASES:
-            if i + 1 >= len(argv) or not argv[i + 1].isdigit():
-                raise SystemExit(f"需要为 {token} 指定群编号，例如: {token} 1")
-            recommends[PLATFORM_ALIASES[token]] = int(argv[i + 1])
-            i += 2
-            continue
-        raise SystemExit(
-            "用法:\n"
-            "  python gen_index.py <Windows群编号>     # CI：只改 Windows，Android/Mac 自动\n"
-            "  python gen_index.py channel            # Windows 推频道，Android/Mac 自动选群\n"
-            "  python gen_index.py windows 28\n"
-            "  python gen_index.py windows 28 android 2 mac 1   # 调试可手动覆盖"
-        )
-
-    return recommends, is_channel
+            return (
+                {"url": g["url"], "name": g["name"], "gid": g["gid"], "kind": "group"},
+                idx,
+                f"keep#{idx + 1}",
+            )
+        if idx is not None:
+            print(
+                f"保持[{label}]: 状态群已下架，改用第一个可用群",
+                file=sys.stderr,
+            )
+    for i, g in enumerate(groups):
+        if g.get("active"):
+            print(
+                f"保持[{label}]: 无有效粘性，回退 #{i + 1} {g['name']}",
+                file=sys.stderr,
+            )
+            return (
+                {"url": g["url"], "name": g["name"], "gid": g["gid"], "kind": "group"},
+                i,
+                f"keep-fallback#{i + 1}",
+            )
+    g = groups[0]
+    return (
+        {"url": g["url"], "name": g["name"], "gid": g["gid"], "kind": "group"},
+        0,
+        "keep-fallback#1",
+    )
 
 
 def pick_recommend(groups: list[dict], index_1based: int, platform: str) -> dict:
@@ -211,113 +324,262 @@ def fetch_group_occupancy(gids: list[str]) -> dict[str, dict]:
     return out
 
 
-def auto_recommend_index(groups: list[dict], platform: str) -> int:
-    """自动选推荐群（0-based）：有空位的优先，空位多者优先；失败则第一个可用群。"""
+def free_slots_of(info: dict | None) -> int | None:
+    """有 known 数据时返回空位数；否则 None。"""
+    if not info or not info.get("known"):
+        return None
+    free = info.get("free_slots")
+    if free is not None:
+        return max(0, int(free))
+    mx = int(info.get("max_member_count") or 0)
+    cur = int(info.get("member_count") or 0)
+    if mx <= 0:
+        return None
+    return max(0, mx - cur)
+
+
+def load_sticky_from_index(index_path: Path) -> dict[str, dict]:
+    """从现有 index.html 的 RECOMMENDS 读取粘性推荐（platform -> {gid, name}）。"""
+    if not index_path.is_file():
+        return {}
+    try:
+        text = index_path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    marker = "const RECOMMENDS = "
+    start = text.find(marker)
+    if start < 0:
+        return {}
+    start += len(marker)
+    end = text.find(";", start)
+    if end < 0:
+        return {}
+    try:
+        data = json.loads(text[start:end].strip())
+    except json.JSONDecodeError as e:
+        print(f"解析 index.html RECOMMENDS 失败 ({e})，忽略粘性", file=sys.stderr)
+        return {}
+    out: dict[str, dict] = {}
+    if not isinstance(data, dict):
+        return out
+    for p, rec in data.items():
+        if p not in PLATFORMS or not isinstance(rec, dict):
+            continue
+        # 仅群推荐带 gid；频道模式没有可粘性的群号
+        if rec.get("kind") == "group" and rec.get("gid"):
+            out[p] = {
+                "gid": str(rec["gid"]),
+                "name": rec.get("name") or "",
+            }
+    return out
+
+
+def index_of_gid(groups: list[dict], gid: str) -> int | None:
+    gid = str(gid)
+    for i, g in enumerate(groups):
+        if str(g["gid"]) == gid:
+            return i
+    return None
+
+
+def first_with_free_slots(groups: list[dict], platform: str) -> int:
+    """按列表顺序找第一个有空位的 active 群；分批查询，找到即停。"""
     active = [(i, g) for i, g in enumerate(groups) if g.get("active")]
     if not active:
-        print(f"自动选群[{PLATFORM_LABELS[platform]}]: 无可用群，回退索引 0", file=sys.stderr)
-        return 0
-
-    gids = [g["gid"] for _, g in active]
-    occ = fetch_group_occupancy(gids)
-
-    best_i = active[0][0]
-    best_key = (-1, -1)  # (has_info, free_slots) — 无数据时 has_info=0
-    detail = []
-    for i, g in active:
-        info = occ.get(str(g["gid"]))
-        if not info or not info.get("known"):
-            detail.append(f"#{i + 1} {g['name']}=未知")
-            continue
-        free = info.get("free_slots")
-        if free is None:
-            mx = int(info.get("max_member_count") or 0)
-            cur = int(info.get("member_count") or 0)
-            free = max(0, mx - cur) if mx > 0 else 0
-        free = int(free)
-        key = (1, free)
-        cur = info.get("member_count")
-        mx = info.get("max_member_count")
-        detail.append(
-            f"#{i + 1} {g['name']}="
-            f"{cur if cur is not None else '?'}/{mx if mx is not None else '?'} 余{free}"
-        )
-        if key > best_key:
-            best_key = key
-            best_i = i
-
-    if best_key[0] < 0:
         print(
-            f"自动选群[{PLATFORM_LABELS[platform]}]: 人数均未知，使用第一个可用群 "
-            f"#{active[0][0] + 1} {active[0][1]['name']}",
+            f"自动选群[{PLATFORM_LABELS[platform]}]: 无可用群，回退索引 0",
             file=sys.stderr,
         )
-        return active[0][0]
+        return 0
 
+    label = PLATFORM_LABELS[platform]
+    checked = 0
+    for start in range(0, len(active), OCCUPANCY_BATCH):
+        batch = active[start : start + OCCUPANCY_BATCH]
+        occ = fetch_group_occupancy([g["gid"] for _, g in batch])
+        for i, g in batch:
+            checked += 1
+            free = free_slots_of(occ.get(str(g["gid"])))
+            if free is None:
+                print(
+                    f"自动选群[{label}]: #{i + 1} {g['name']} 人数未知，跳过",
+                    file=sys.stderr,
+                )
+                continue
+            if free > 0:
+                print(
+                    f"自动选群[{label}]: 选中第一个有空位 "
+                    f"#{i + 1} {g['name']} 余{free}"
+                    f"（已查 {checked} 个）",
+                    file=sys.stderr,
+                )
+                return i
+            print(
+                f"自动选群[{label}]: #{i + 1} {g['name']} 已满，继续",
+                file=sys.stderr,
+            )
+
+    fb = active[0][0]
     print(
-        f"自动选群[{PLATFORM_LABELS[platform]}]: 选中 #{best_i + 1} {groups[best_i]['name']} "
-        f"(空位优先) | " + "; ".join(detail),
+        f"自动选群[{label}]: 未找到确认有空位的群，回退第一个可用 "
+        f"#{fb + 1} {groups[fb]['name']}",
         file=sys.stderr,
     )
-    return best_i
+    return fb
+
+
+def sticky_auto_recommend_index(
+    groups: list[dict],
+    platform: str,
+    sticky_gid: str | None,
+) -> tuple[int, str]:
+    """粘性自动：未满保持；满了/下架则按序选第一个有空位。返回 (0-based, source)。"""
+    label = PLATFORM_LABELS[platform]
+    active = [(i, g) for i, g in enumerate(groups) if g.get("active")]
+    if not active:
+        return 0, "auto#1-empty"
+
+    sticky_i: int | None = None
+    if sticky_gid:
+        sticky_i = index_of_gid(groups, sticky_gid)
+        if sticky_i is None:
+            print(
+                f"粘性[{label}]: 状态群 {sticky_gid} 不在配置中，重新选群",
+                file=sys.stderr,
+            )
+        elif not groups[sticky_i].get("active"):
+            print(
+                f"粘性[{label}]: #{sticky_i + 1} {groups[sticky_i]['name']} 已下架，重新选群",
+                file=sys.stderr,
+            )
+            sticky_i = None
+
+    if sticky_i is not None:
+        g = groups[sticky_i]
+        occ = fetch_group_occupancy([g["gid"]])
+        free = free_slots_of(occ.get(str(g["gid"])))
+        if free is None:
+            # 查失败：保持旧推荐，避免乱跳
+            print(
+                f"粘性[{label}]: 保持 #{sticky_i + 1} {g['name']}（人数暂不可用）",
+                file=sys.stderr,
+            )
+            return sticky_i, f"sticky#{sticky_i + 1}-keep-unknown"
+        if free > 0:
+            print(
+                f"粘性[{label}]: 保持 #{sticky_i + 1} {g['name']} 余{free}",
+                file=sys.stderr,
+            )
+            return sticky_i, f"sticky#{sticky_i + 1}"
+        print(
+            f"粘性[{label}]: #{sticky_i + 1} {g['name']} 已满，按序选第一个有空位",
+            file=sys.stderr,
+        )
+
+    idx = first_with_free_slots(groups, platform)
+    return idx, f"auto-first-free#{idx + 1}"
 
 
 def resolve_recommend(
     platform: str,
     groups: list[dict],
-    specified_1based: int | None,
     *,
-    windows_channel_mode: bool,
+    mode: str,
+    manual_1based: int | None,
     channel: dict | None,
+    sticky_gid: str | None,
 ) -> tuple[dict, int, str]:
     """返回 (recommend字典, recommendIndex 0-based, 来源说明)。"""
-    # Windows 频道模式
-    if platform == "windows" and windows_channel_mode and channel:
-        return (
-            {"url": channel["url"], "name": channel["name"], "gid": "", "kind": "channel"},
-            -1,
-            "channel",
-        )
+    if mode == "freeze":
+        return freeze_recommend(groups, platform, sticky_gid)
 
-    if specified_1based is not None:
-        rec = pick_recommend(groups, specified_1based, platform)
+    if mode == "channel":
+        if channel:
+            return (
+                {
+                    "url": channel["url"],
+                    "name": channel["name"],
+                    "gid": "",
+                    "kind": "channel",
+                },
+                -1,
+                "channel",
+            )
+        print(
+            f"{PLATFORM_LABELS[platform]}: 无频道配置，回退粘性自动",
+            file=sys.stderr,
+        )
+        mode = "auto"
+
+    if mode == "manual":
+        if manual_1based is None:
+            raise ValueError(f"{PLATFORM_LABELS[platform]} manual 模式缺少群编号")
+        rec = pick_recommend(groups, manual_1based, platform)
         return (
             {"url": rec["url"], "name": rec["name"], "gid": rec["gid"], "kind": "group"},
-            specified_1based - 1,
-            f"manual#{specified_1based}",
+            manual_1based - 1,
+            f"manual#{manual_1based}",
         )
 
-    # 自动（Android / Mac，或 Windows channel 模式下无频道时）
-    idx = auto_recommend_index(groups, platform)
+    # auto：粘性
+    idx, source = sticky_auto_recommend_index(groups, platform, sticky_gid)
     rec = groups[idx]
     return (
         {"url": rec["url"], "name": rec["name"], "gid": rec["gid"], "kind": "group"},
         idx,
-        f"auto#{idx + 1}",
+        source,
     )
 
 
 def main() -> None:
     base = Path(__file__).resolve().parent
-    recommends, windows_channel_mode = parse_args(sys.argv[1:])
+    plan = parse_args(sys.argv[1:])
     channels = load_channels(base / CHANNELS_FILE)
+
+    index_path = base / "index.html"
+    sticky = load_sticky_from_index(index_path)
+    if sticky:
+        print(
+            "从 index.html RECOMMENDS 读取粘性: "
+            + ", ".join(f"{p}={sticky[p].get('gid')}" for p in sticky),
+            file=sys.stderr,
+        )
+    else:
+        print("无可用粘性状态（首次生成或尚无群推荐）", file=sys.stderr)
+
+    # 清理误留的旧状态文件（粘性已并入 index.html）
+    legacy_state = base / "recommend_state.json"
+    if legacy_state.is_file():
+        try:
+            legacy_state.unlink()
+            print("已删除遗留 recommend_state.json", file=sys.stderr)
+        except OSError as e:
+            print(f"删除 recommend_state.json 失败: {e}", file=sys.stderr)
+
+    touch = plan["touch"]
+    print(
+        "本轮操作平台: "
+        + (", ".join(PLATFORM_LABELS[p] for p in PLATFORMS if p in touch) or "(无)"),
+        file=sys.stderr,
+    )
 
     platforms_data: dict[str, dict] = {}
     for platform in PLATFORMS:
         groups = load_groups(base / PLATFORM_FILES[platform])
         ch = channels.get(platform)
-        specified = recommends.get(platform)
-        # Android/Mac：除非关键字显式传入，否则强制自动（忽略误传）
-        if platform in AUTO_PLATFORMS and specified is not None:
-            # 仅当通过关键字 android N / mac N 传入时 keeps specified；
-            # parse_args 已保证单数字不会写入 android/mac
-            pass
+        sticky_gid = None
+        entry = sticky.get(platform)
+        if entry:
+            sticky_gid = str(entry.get("gid") or "") or None
+        mode = plan["mode"].get(platform, "freeze")
+        manual_n = plan["manual"].get(platform)
         recommend, rec_index, source = resolve_recommend(
             platform,
             groups,
-            specified,
-            windows_channel_mode=windows_channel_mode,
+            mode=mode,
+            manual_1based=manual_n,
             channel=ch,
+            sticky_gid=sticky_gid,
         )
         platforms_data[platform] = {
             "label": PLATFORM_LABELS[platform],
@@ -401,7 +663,11 @@ def main() -> None:
             f'<a href="{url}" onclick="handleLinkClick(event)">{label}</a></li>\n'
         )
 
-    header_extra = " channel-header" if windows_channel_mode else ""
+    # 任一侧默认推荐是频道时，用频道风格头图（页面选平台后仍会切换文案）
+    any_channel_rec = any(
+        platforms_data[p]["recommend"]["kind"] == "channel" for p in PLATFORMS
+    )
+    header_extra = " channel-header" if any_channel_rec else ""
 
     # JS 用的推荐映射（平台 → 跳转目标）
     recommend_map = {
@@ -1072,9 +1338,54 @@ def main() -> None:
             ).forEach(applyChannelRecommendMark);
         }}
 
-        function selectPlatform(platform) {{
+        function normalizePlatform(raw) {{
+            if (!raw) return "";
+            const s = String(raw).trim().toLowerCase();
+            const map = {{
+                windows: "windows", win: "windows", win32: "windows", pc: "windows",
+                android: "android", and: "android",
+                mac: "mac", macos: "mac", osx: "mac", darwin: "mac",
+            }};
+            return map[s] || "";
+        }}
+
+        function platformFromUrl() {{
+            try {{
+                const params = new URLSearchParams(window.location.search);
+                const keys = ["platform", "os", "p", "client"];
+                for (let i = 0; i < keys.length; i++) {{
+                    const v = normalizePlatform(params.get(keys[i]));
+                    if (v && RECOMMENDS[v]) return v;
+                }}
+                // 兼容 #windows / #mac / #platform=android
+                const hash = (window.location.hash || "").replace(/^#/, "");
+                if (hash) {{
+                    let h = hash;
+                    const eq = hash.indexOf("=");
+                    if (eq >= 0) h = hash.slice(eq + 1);
+                    const v = normalizePlatform(h);
+                    if (v && RECOMMENDS[v]) return v;
+                }}
+            }} catch (e) {{}}
+            return "";
+        }}
+
+        function syncPlatformToUrl(platform) {{
+            try {{
+                const url = new URL(window.location.href);
+                url.searchParams.set("platform", platform);
+                ["os", "p", "client"].forEach((k) => url.searchParams.delete(k));
+                const next = url.pathname + url.search + (url.hash || "");
+                if (next !== window.location.pathname + window.location.search + window.location.hash) {{
+                    history.replaceState(null, "", next);
+                }}
+            }} catch (e) {{}}
+        }}
+
+        function selectPlatform(platform, options) {{
             const rec = RECOMMENDS[platform];
             if (!rec) return;
+            options = options || {{}};
 
             // 主动点选平台视为新意图：重新开启自动跳转
             userCancelled = false;
@@ -1114,7 +1425,22 @@ def main() -> None:
             primary.href = rec.url;
             primary.classList.remove("is-disabled");
             primary.setAttribute("aria-disabled", "false");
+            if (!options.skipUrlSync) {{
+                syncPlatformToUrl(platform);
+            }}
             startRedirect(rec.url);
+        }}
+
+        // URL 带平台时自动选中，无需手动点
+        // 例: ?platform=windows  ?os=android  ?p=mac  #windows
+        function initPlatformFromUrl() {{
+            const p = platformFromUrl();
+            if (p) selectPlatform(p, {{ skipUrlSync: true }});
+        }}
+        if (document.readyState === "loading") {{
+            document.addEventListener("DOMContentLoaded", initPlatformFromUrl);
+        }} else {{
+            initPlatformFromUrl();
         }}
     </script>
 </head>
@@ -1139,7 +1465,7 @@ def main() -> None:
                         onclick="selectPlatform('mac')">Mac</button>
                 </div>
             </div>
-            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。</p>
+            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。也可通过链接指定，例如 <code>?platform=windows</code>。</p>
 
             <p>
                 <a id="primaryLink" href="#" class="primary-link chroma is-disabled"
@@ -1166,7 +1492,7 @@ def main() -> None:
 </html>
 """
 
-    out = base / "index.html"
+    out = index_path
     out.write_text(index_html, encoding="utf-8")
 
     # 清理旧的分平台页面
@@ -1196,6 +1522,7 @@ def main() -> None:
             f", 配置 {PLATFORM_FILES[p]}{ch_info}"
         )
     print(f"  - 频道配置: {CHANNELS_FILE} ({len(channels)} 个平台)")
+    print("  - 粘性状态: index.html RECOMMENDS")
 
 
 if __name__ == "__main__":

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -184,17 +184,28 @@ def main() -> None:
             # 仅「群推荐」时才标 data-recommend；选平台后由 JS 高亮
             is_rec = data["recommend"]["kind"] == "group" and i == data["recommendIndex"]
             rec_attr = ' data-recommend="1"' if is_rec else ""
+            # 头像/人数由前端调 groupinfo API 填充；失败则保持隐藏
+            row_inner = (
+                f'<img class="group-avatar" alt="" width="40" height="40" hidden>'
+                f'<div class="group-body">'
+                f'<span class="group-title">{label}</span>'
+                f'<span class="group-meta" hidden></span>'
+                f"</div>"
+            )
             if not g["active"]:
                 items.append(
                     f'<li class="group-item" data-platform="{platform}" '
-                    f'data-label="{label}"{rec_attr}>'
-                    f'<span class="disabled">{label}</span></li>'
+                    f'data-gid="{esc(gid)}" data-label="{label}"{rec_attr}>'
+                    f'<div class="group-row disabled-row">'
+                    f'{row_inner}</div></li>'
                 )
             else:
                 items.append(
                     f'<li class="group-item" data-platform="{platform}" '
-                    f'data-label="{label}" data-href="{esc(url)}"{rec_attr}>'
-                    f'<a href="{esc(url)}" onclick="handleLinkClick(event)">{label}</a></li>'
+                    f'data-gid="{esc(gid)}" data-label="{label}" '
+                    f'data-href="{esc(url)}"{rec_attr}>'
+                    f'<a class="group-link" href="{esc(url)}" onclick="handleLinkClick(event)">'
+                    f'<div class="group-row">{row_inner}</div></a></li>'
                 )
         return "\n".join(items)
 
@@ -480,6 +491,67 @@ def main() -> None:
             background: #fff4e8;
             border-left: 4px solid #ff6600;
         }}
+        .group-link {{
+            display: block;
+            color: inherit;
+            text-decoration: none;
+            font-weight: normal;
+        }}
+        .group-link:hover {{ text-decoration: none; }}
+        .group-link:hover .group-title {{ text-decoration: underline; color: #004499; }}
+        .group-row {{
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }}
+        .group-avatar {{
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            object-fit: cover;
+            flex-shrink: 0;
+            background: #e8eef8;
+        }}
+        .group-body {{
+            min-width: 0;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }}
+        .group-title {{
+            font-weight: bold;
+            color: #0066cc;
+            word-break: break-all;
+        }}
+        .group-item.is-recommend .group-title {{ color: #ff6600; }}
+        .group-meta {{
+            color: #666;
+            font-size: 0.9em;
+        }}
+        .group-meta .full {{ color: #cc4444; }}
+        .group-meta .ok {{ color: #2a7a2a; }}
+        .disabled-row .group-title {{ color: #999; font-weight: normal; }}
+        .header-rec-row {{
+            display: none;
+            align-items: center;
+            gap: 12px;
+            margin: 8px 0 4px;
+        }}
+        .header-rec-row.is-visible {{ display: flex; }}
+        .header-avatar {{
+            width: 48px;
+            height: 48px;
+            border-radius: 10px;
+            object-fit: cover;
+            background: #e8eef8;
+            flex-shrink: 0;
+        }}
+        .header-members {{
+            margin: 0;
+            color: #555;
+            font-size: 0.95em;
+        }}
         .lists-heading {{ margin: 24px 0 8px; font-size: 1.15em; }}
         .lists-placeholder {{ color: #888; margin: 12px 0 24px; }}
         .lists-placeholder.is-hidden {{ display: none; }}
@@ -491,6 +563,9 @@ def main() -> None:
         const RECOMMENDS = {recommend_json};
         const CHANNELS = {channels_json};
         const PLATFORM_LABELS = {{ windows: "Windows", android: "Android", mac: "Mac" }};
+        // 对外 groupinfo API（头像 + 人数）；失败则不展示
+        const GROUPINFO_API = "https://join.maameow.com/api/groupinfo";
+        const groupInfoCache = Object.create(null); // gid -> info | null(failed)
 
         // 必须用户主动选择平台后，才启动自动跳转
         let redirectEnabled = false;
@@ -559,8 +634,217 @@ def main() -> None:
             }}
         }}
 
-        function resetListRecommendMarks(selector) {{
-            document.querySelectorAll(selector).forEach((li) => {{
+        function formatMembers(info) {{
+            if (!info || !info.known) return "";
+            const cur = info.member_count;
+            const max = info.max_member_count;
+            if (!max || max <= 0) return "";
+            const free = typeof info.free_slots === "number" ? info.free_slots : Math.max(0, max - cur);
+            const cls = free <= 0 ? "full" : "ok";
+            const freeText = free <= 0 ? "已满" : ("余 " + free);
+            return '<span class="' + cls + '">' + cur + " / " + max + " · " + freeText + "</span>";
+        }}
+
+        function applyInfoToItem(li, info) {{
+            const avatar = li.querySelector(".group-avatar");
+            const meta = li.querySelector(".group-meta");
+            if (!info || !info.known) {{
+                if (avatar) {{
+                    avatar.hidden = true;
+                    avatar.removeAttribute("src");
+                }}
+                if (meta) {{
+                    meta.hidden = true;
+                    meta.innerHTML = "";
+                }}
+                return;
+            }}
+            if (avatar && info.avatar_url) {{
+                avatar.src = info.avatar_url;
+                avatar.alt = (info.group_name || "") + " 头像";
+                avatar.hidden = false;
+            }} else if (avatar) {{
+                avatar.hidden = true;
+            }}
+            const html = formatMembers(info);
+            if (meta) {{
+                if (html) {{
+                    meta.innerHTML = html;
+                    meta.hidden = false;
+                }} else {{
+                    meta.hidden = true;
+                    meta.innerHTML = "";
+                }}
+            }}
+        }}
+
+        function clearHeaderRecExtra() {{
+            const row = document.getElementById("headerRecRow");
+            const img = document.getElementById("headerAvatar");
+            const members = document.getElementById("headerMembers");
+            if (row) row.classList.remove("is-visible");
+            if (img) {{
+                img.hidden = true;
+                img.removeAttribute("src");
+            }}
+            if (members) {{
+                members.hidden = true;
+                members.innerHTML = "";
+            }}
+        }}
+
+        function applyHeaderRecExtra(info) {{
+            const row = document.getElementById("headerRecRow");
+            const img = document.getElementById("headerAvatar");
+            const members = document.getElementById("headerMembers");
+            if (!row || !info || !info.known) {{
+                clearHeaderRecExtra();
+                return;
+            }}
+            let show = false;
+            if (img && info.avatar_url) {{
+                img.src = info.avatar_url;
+                img.alt = (info.group_name || "推荐群") + " 头像";
+                img.hidden = false;
+                show = true;
+            }} else if (img) {{
+                img.hidden = true;
+            }}
+            const html = formatMembers(info);
+            if (members && html) {{
+                members.innerHTML = html;
+                members.hidden = false;
+                show = true;
+            }} else if (members) {{
+                members.hidden = true;
+                members.innerHTML = "";
+            }}
+            row.classList.toggle("is-visible", show);
+        }}
+
+        function chunk(arr, size) {{
+            const out = [];
+            for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+            return out;
+        }}
+
+        function applyPlatformInfoForIds(platform, ids, recGid) {{
+            // 只刷新本批相关 DOM，有结果就先展示
+            ids.forEach((id) => {{
+                if (!(id in groupInfoCache)) return;
+                document.querySelectorAll(
+                    '.group-item[data-platform="' + platform + '"][data-gid="' + id + '"]'
+                ).forEach((li) => {{
+                    applyInfoToItem(li, groupInfoCache[id]);
+                }});
+            }});
+            if (recGid && (recGid in groupInfoCache)) {{
+                applyHeaderRecExtra(groupInfoCache[recGid]);
+            }}
+        }}
+
+        async function fetchGroupInfoBatch(ids, onPartDone) {{
+            const missing = ids.filter((id) => !(id in groupInfoCache));
+            // 已有缓存的也回调，方便立刻上屏
+            const already = ids.filter((id) => id in groupInfoCache);
+            if (already.length && typeof onPartDone === "function") {{
+                onPartDone(already);
+            }}
+            if (!missing.length) return;
+
+            // 小批量串行；每批返回立刻 onPartDone，不用等全部
+            for (const part of chunk(missing, 5)) {{
+                try {{
+                    const url = GROUPINFO_API + "?ids=" + encodeURIComponent(part.join(","));
+                    const resp = await fetch(url, {{
+                        method: "GET",
+                        mode: "cors",
+                        credentials: "omit",
+                        cache: "default",
+                    }});
+                    if (!resp.ok) {{
+                        part.forEach((id) => {{ groupInfoCache[id] = null; }});
+                        if (typeof onPartDone === "function") onPartDone(part);
+                        continue;
+                    }}
+                    const body = await resp.json();
+                    if (!body || body.code !== 0 || !body.data) {{
+                        part.forEach((id) => {{ groupInfoCache[id] = null; }});
+                        if (typeof onPartDone === "function") onPartDone(part);
+                        continue;
+                    }}
+                    const list = Array.isArray(body.data.groups)
+                        ? body.data.groups
+                        : (body.data.group_id ? [body.data] : []);
+                    const byId = Object.create(null);
+                    list.forEach((g) => {{
+                        if (g && g.group_id) byId[String(g.group_id)] = g;
+                    }});
+                    part.forEach((id) => {{
+                        const g = byId[id];
+                        groupInfoCache[id] = (g && g.known) ? g : null;
+                    }});
+                }} catch (e) {{
+                    part.forEach((id) => {{ groupInfoCache[id] = null; }});
+                }}
+                if (typeof onPartDone === "function") onPartDone(part);
+            }}
+        }}
+
+        async function loadPlatformGroupInfo(platform) {{
+            const items = document.querySelectorAll(
+                '.group-item[data-platform="' + platform + '"][data-gid]'
+            );
+            const ids = [];
+            items.forEach((li) => {{
+                const gid = li.getAttribute("data-gid");
+                if (gid) ids.push(gid);
+            }});
+            // 推荐群也查一下（可能与列表同一 gid）
+            const rec = RECOMMENDS[platform];
+            let recGid = "";
+            if (rec && rec.kind !== "channel" && rec.gid) {{
+                recGid = String(rec.gid);
+                ids.push(recGid);
+            }} else {{
+                clearHeaderRecExtra();
+            }}
+            // 推荐群优先拉取，顶部头像/人数更早出现
+            let unique = Array.from(new Set(ids));
+            if (recGid) {{
+                unique = [recGid].concat(unique.filter((id) => id !== recGid));
+            }}
+            if (!unique.length) {{
+                clearHeaderRecExtra();
+                return;
+            }}
+            // 已缓存的立刻上屏
+            const cachedNow = unique.filter((id) => id in groupInfoCache);
+            if (cachedNow.length) {{
+                applyPlatformInfoForIds(platform, cachedNow, recGid);
+            }}
+            // 逐批回调：哪批好了就先画哪批
+            await fetchGroupInfoBatch(unique, (partIds) => {{
+                // 平台已切换则丢弃过期回调
+                if (currentPlatform !== platform) return;
+                applyPlatformInfoForIds(platform, partIds, recGid);
+            }});
+        }}
+
+        function resetGroupRecommendMarks() {{
+            document.querySelectorAll(".group-item").forEach((li) => {{
+                li.classList.remove("is-recommend");
+                const title = li.querySelector(".group-title");
+                if (!title) return;
+                const label = li.getAttribute("data-label") || "";
+                // 去掉「 - 当前推荐」后缀
+                title.textContent = label;
+                title.classList.remove("current");
+            }});
+        }}
+
+        function resetChannelRecommendMarks() {{
+            document.querySelectorAll(".channel-item").forEach((li) => {{
                 li.classList.remove("is-recommend");
                 if (li.querySelector(".disabled")) return;
                 const href = li.getAttribute("data-href");
@@ -571,7 +855,17 @@ def main() -> None:
             }});
         }}
 
-        function applyRecommendMark(li) {{
+        function applyGroupRecommendMark(li) {{
+            li.classList.add("is-recommend");
+            const title = li.querySelector(".group-title");
+            const label = li.getAttribute("data-label") || "";
+            if (title) {{
+                title.textContent = label + " - 当前推荐";
+                title.classList.add("current");
+            }}
+        }}
+
+        function applyChannelRecommendMark(li) {{
             li.classList.add("is-recommend");
             const label = li.getAttribute("data-label") || "";
             li.innerHTML = '<strong><span class="current">' + label +
@@ -579,8 +873,8 @@ def main() -> None:
         }}
 
         function markPlatformRecommend(platform) {{
-            resetListRecommendMarks(".group-item");
-            resetListRecommendMarks(".channel-item");
+            resetGroupRecommendMarks();
+            resetChannelRecommendMarks();
 
             const listsPlaceholder = document.getElementById("listsPlaceholder");
             if (listsPlaceholder) listsPlaceholder.classList.add("is-hidden");
@@ -608,13 +902,12 @@ def main() -> None:
                 channelBlock.classList.toggle("is-empty", !hasChannel);
             }}
 
-            // 高亮当前推荐（群或频道）
             document.querySelectorAll(
                 '.group-item[data-platform="' + platform + '"][data-recommend="1"]'
-            ).forEach(applyRecommendMark);
+            ).forEach(applyGroupRecommendMark);
             document.querySelectorAll(
                 '.channel-item[data-platform="' + platform + '"][data-recommend="1"]'
-            ).forEach(applyRecommendMark);
+            ).forEach(applyChannelRecommendMark);
         }}
 
         function selectPlatform(platform) {{
@@ -630,6 +923,9 @@ def main() -> None:
             }});
 
             markPlatformRecommend(platform);
+            clearHeaderRecExtra();
+            // 异步拉头像/人数；失败静默，不展示
+            loadPlatformGroupInfo(platform);
 
             const title = document.getElementById("join-title");
             const gidEl = document.getElementById("join-gid");
@@ -664,6 +960,10 @@ def main() -> None:
     <div class="container">
         <div id="join-header" class="header{header_extra}">
             <h2 id="join-title">欢迎加入 MAA 交流群</h2>
+            <div id="headerRecRow" class="header-rec-row">
+                <img id="headerAvatar" class="header-avatar" alt="" width="48" height="48" hidden>
+                <p id="headerMembers" class="header-members" hidden></p>
+            </div>
             <p id="join-gid" style="display:none"></p>
 
             <div class="platform-row">

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -769,6 +769,7 @@ def main() -> None:
         .primary-link .btn-text {{
             position: relative;
             z-index: 2;
+            border-radius: 8px;
         }}
         .primary-link.is-disabled {{
             pointer-events: none;
@@ -784,9 +785,26 @@ def main() -> None:
         .primary-link.is-disabled.chroma::after {{
             display: none;
         }}
-        /* 无缝炫彩：色带重复两份，translateX 平移 50% 避免顿挫 */
+        /* 满幅流动炫彩（中等明度）；文字胶囊偏实，保证可读 */
         .primary-link.chroma:not(.is-disabled) {{
-            background: transparent;
+            background: #2a2048;
+            color: #fff;
+            box-shadow: 0 4px 16px rgba(114, 46, 209, 0.3);
+        }}
+        .primary-link.chroma:not(.is-disabled) .btn-text {{
+            position: relative;
+            z-index: 2;
+            display: inline-block;
+            padding: 5px 14px;
+            border-radius: 8px;
+            background: rgba(16, 12, 32, 0.8);
+            box-shadow:
+                0 0 0 1px rgba(255, 255, 255, 0.14) inset,
+                0 2px 8px rgba(0, 0, 0, 0.22);
+            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+            letter-spacing: 0.02em;
+            -webkit-backdrop-filter: blur(6px);
+            backdrop-filter: blur(6px);
         }}
         .primary-link.chroma:not(.is-disabled)::before {{
             content: "";
@@ -796,6 +814,7 @@ def main() -> None:
             height: 100%;
             width: 200%;
             z-index: 0;
+            opacity: 0.88;
             background: linear-gradient(
                 90deg,
                 #ff4d4f, #fa8c16, #fadb14, #52c41a, #13c2c2, #1677ff, #722ed1, #eb2f96,
@@ -809,39 +828,47 @@ def main() -> None:
         .primary-link.chroma:not(.is-disabled)::after {{
             content: "";
             position: absolute;
-            top: 0;
-            left: -40%;
-            width: 40%;
-            height: 100%;
+            inset: 0;
             z-index: 1;
-            background: linear-gradient(
-                100deg,
-                transparent 0%,
-                rgba(255, 255, 255, 0.15) 40%,
-                rgba(255, 255, 255, 0.45) 50%,
-                rgba(255, 255, 255, 0.15) 60%,
-                transparent 100%
-            );
-            animation: chroma-shine 2.5s linear infinite;
+            background:
+                linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.1) 100%),
+                linear-gradient(
+                    100deg,
+                    transparent 0%,
+                    transparent 40%,
+                    rgba(255, 255, 255, 0.2) 50%,
+                    transparent 60%,
+                    transparent 100%
+                );
+            background-size: 100% 100%, 42% 100%;
+            background-repeat: no-repeat, no-repeat;
+            background-position: 0 0, -42% 0;
+            animation: chroma-shine 2.8s linear infinite;
             pointer-events: none;
-            will-change: transform;
+            will-change: background-position;
         }}
         .primary-link.chroma:not(.is-disabled):hover {{
-            filter: brightness(1.05);
-            box-shadow: 0 6px 16px rgba(114, 46, 209, 0.35);
+            filter: brightness(1.05) saturate(1.04);
+            box-shadow: 0 6px 20px rgba(114, 46, 209, 0.38);
             text-decoration: none;
             color: #fff;
         }}
+        .primary-link.chroma:not(.is-disabled):hover .btn-text {{
+            background: rgba(16, 12, 32, 0.86);
+        }}
         .primary-link.chroma:not(.is-disabled):active {{
-            filter: brightness(0.98);
+            filter: brightness(0.97);
+        }}
+        .primary-link.chroma:not(.is-disabled):active .btn-text {{
+            background: rgba(16, 12, 32, 0.9);
         }}
         @keyframes chroma-slide {{
             from {{ transform: translateX(0); }}
             to {{ transform: translateX(-50%); }}
         }}
         @keyframes chroma-shine {{
-            from {{ transform: translateX(0); }}
-            to {{ transform: translateX(350%); }}
+            from {{ background-position: 0 0, -42% 0; }}
+            to {{ background-position: 0 0, 142% 0; }}
         }}
         @media (prefers-reduced-motion: reduce) {{
             .primary-link.chroma:not(.is-disabled)::before,
@@ -850,17 +877,25 @@ def main() -> None:
             }}
             .primary-link.chroma:not(.is-disabled)::before {{
                 width: 100%;
-                background: #0066cc;
+                opacity: 0.92;
+                background: linear-gradient(135deg, #1677ff 0%, #722ed1 55%, #eb2f96 100%);
                 transform: none;
             }}
             .primary-link.chroma:not(.is-disabled)::after {{
-                display: none;
+                background: linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.1) 100%);
+                animation: none;
             }}
             .primary-link.chroma:not(.is-disabled) {{
-                box-shadow: none;
+                box-shadow: 0 4px 12px rgba(114, 46, 209, 0.3);
             }}
-            .channel-header .primary-link.chroma:not(.is-disabled)::before {{
-                background: #7c4dff;
+            .primary-link.chroma:not(.is-disabled) .btn-text {{
+                background: rgba(16, 12, 32, 0.8);
+                text-shadow: none;
+                -webkit-backdrop-filter: none;
+                backdrop-filter: none;
+            }}
+            .header.channel-header .primary-link.chroma:not(.is-disabled)::before {{
+                background: linear-gradient(135deg, #722ed1 0%, #b37feb 100%);
             }}
         }}
         .cancel-btn {{
@@ -886,7 +921,6 @@ def main() -> None:
             border-left: 4px solid #7c4dff;
         }}
         .tip {{ color: #666; font-size: 0.95em; }}
-        .hint {{ color: #555; margin: 8px 0 0; }}
         /* 下方群列表：按平台分块，默认隐藏，选中后只显示对应平台 */
         .group-section {{
             display: none;
@@ -1488,7 +1522,6 @@ def main() -> None:
                         onclick="selectPlatform('mac')">Mac</button>
                 </div>
             </div>
-            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。也可通过链接指定，例如 <code>?platform=windows</code>。</p>
 
             <p>
                 <a id="primaryLink" href="#" class="primary-link chroma is-disabled"

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -1015,7 +1015,7 @@ def main() -> None:
             userCancelled = true;
             stopCountdown();
             const text = document.getElementById("redirectText");
-            if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+            if (text) text.textContent = "自动跳转已取消，可点击上方按钮或下方群链接加入";
         }}
 
         function handleLinkClick(event) {{
@@ -1037,7 +1037,7 @@ def main() -> None:
                 // 用户已取消过：只更新链接，不再自动跳
                 currentJoinUrl = url;
                 const text = document.getElementById("redirectText");
-                if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+                if (text) text.textContent = "自动跳转已取消，可点击上方按钮或下方群链接加入";
                 return;
             }}
             currentJoinUrl = url;
@@ -1045,9 +1045,23 @@ def main() -> None:
             countdown = 8;
             if (countdownTimer) clearTimeout(countdownTimer);
 
-            document.getElementById("redirectText").innerHTML =
-                '已选择平台，页面将在 <span id="countdown">' + countdown + '</span> 秒后自动跳转……' +
-                '<button type="button" id="cancelBtn" class="cancel-btn" onclick="cancelRedirect()">取消自动跳转</button>';
+            const text = document.getElementById("redirectText");
+            if (text) {{
+                text.replaceChildren();
+                text.appendChild(document.createTextNode("已选择平台，页面将在 "));
+                const cd = document.createElement("span");
+                cd.id = "countdown";
+                cd.textContent = String(countdown);
+                text.appendChild(cd);
+                text.appendChild(document.createTextNode(" 秒后自动跳转……"));
+                const cancelBtn = document.createElement("button");
+                cancelBtn.type = "button";
+                cancelBtn.id = "cancelBtn";
+                cancelBtn.className = "cancel-btn";
+                cancelBtn.textContent = "取消自动跳转";
+                cancelBtn.addEventListener("click", cancelRedirect);
+                text.appendChild(cancelBtn);
+            }}
             countdownTimer = setTimeout(updateCountdown, 1000);
         }}
 
@@ -1062,15 +1076,30 @@ def main() -> None:
             }}
         }}
 
-        function formatMembers(info) {{
-            if (!info || !info.known) return "";
+        function renderMembersInto(el, info) {{
+            // 用 DOM API 写人数，避免 innerHTML + 外部字段触发 XSS 告警
+            if (!el) return false;
+            el.replaceChildren();
+            if (!info || !info.known) {{
+                el.hidden = true;
+                return false;
+            }}
             const cur = info.member_count;
             const max = info.max_member_count;
-            if (!max || max <= 0) return "";
-            const free = typeof info.free_slots === "number" ? info.free_slots : Math.max(0, max - cur);
-            const cls = free <= 0 ? "full" : "ok";
+            if (!max || max <= 0) {{
+                el.hidden = true;
+                return false;
+            }}
+            const free = typeof info.free_slots === "number"
+                ? info.free_slots
+                : Math.max(0, max - cur);
+            const span = document.createElement("span");
+            span.className = free <= 0 ? "full" : "ok";
             const freeText = free <= 0 ? "已满" : ("余 " + free);
-            return '<span class="' + cls + '">' + cur + " / " + max + " · " + freeText + "</span>";
+            span.textContent = cur + " / " + max + " · " + freeText;
+            el.appendChild(span);
+            el.hidden = false;
+            return true;
         }}
 
         function applyInfoToItem(li, info) {{
@@ -1083,7 +1112,7 @@ def main() -> None:
                 }}
                 if (meta) {{
                     meta.hidden = true;
-                    meta.innerHTML = "";
+                    meta.replaceChildren();
                 }}
                 return;
             }}
@@ -1094,16 +1123,7 @@ def main() -> None:
             }} else if (avatar) {{
                 avatar.hidden = true;
             }}
-            const html = formatMembers(info);
-            if (meta) {{
-                if (html) {{
-                    meta.innerHTML = html;
-                    meta.hidden = false;
-                }} else {{
-                    meta.hidden = true;
-                    meta.innerHTML = "";
-                }}
-            }}
+            renderMembersInto(meta, info);
         }}
 
         function clearHeaderRecExtra() {{
@@ -1117,7 +1137,7 @@ def main() -> None:
             }}
             if (members) {{
                 members.hidden = true;
-                members.innerHTML = "";
+                members.replaceChildren();
             }}
         }}
 
@@ -1138,14 +1158,8 @@ def main() -> None:
             }} else if (img) {{
                 img.hidden = true;
             }}
-            const html = formatMembers(info);
-            if (members && html) {{
-                members.innerHTML = html;
-                members.hidden = false;
+            if (renderMembersInto(members, info)) {{
                 show = true;
-            }} else if (members) {{
-                members.hidden = true;
-                members.innerHTML = "";
             }}
             row.classList.toggle("is-visible", show);
         }}
@@ -1278,8 +1292,13 @@ def main() -> None:
                 const href = li.getAttribute("data-href");
                 const label = li.getAttribute("data-label") || "";
                 if (!href) return;
-                li.innerHTML = '<a href="' + href + '" onclick="handleLinkClick(event)">' +
-                    label + "</a>";
+                // 用 createElement，避免 DOM 属性拼进 innerHTML（CodeQL: DOM text reinterpreted as HTML）
+                li.replaceChildren();
+                const a = document.createElement("a");
+                a.setAttribute("href", href);
+                a.textContent = label;
+                a.addEventListener("click", handleLinkClick);
+                li.appendChild(a);
             }});
         }}
 
@@ -1296,8 +1315,13 @@ def main() -> None:
         function applyChannelRecommendMark(li) {{
             li.classList.add("is-recommend");
             const label = li.getAttribute("data-label") || "";
-            li.innerHTML = '<strong><span class="current">' + label +
-                " - 当前推荐</span></strong>";
+            li.replaceChildren();
+            const strong = document.createElement("strong");
+            const span = document.createElement("span");
+            span.className = "current";
+            span.textContent = label + " - 当前推荐";
+            strong.appendChild(span);
+            li.appendChild(strong);
         }}
 
         function markPlatformRecommend(platform) {{
@@ -1415,7 +1439,11 @@ def main() -> None:
                 title.textContent = "欢迎加入【" + rec.name + "】（" + label + "）";
                 if (rec.gid) {{
                     gidEl.style.display = "";
-                    gidEl.innerHTML = '群号: <strong>' + rec.gid + "</strong>";
+                    gidEl.replaceChildren();
+                    gidEl.appendChild(document.createTextNode("群号: "));
+                    const strong = document.createElement("strong");
+                    strong.textContent = String(rec.gid);
+                    gidEl.appendChild(strong);
                 }} else {{
                     gidEl.style.display = "none";
                 }}

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -1286,19 +1286,15 @@ def main() -> None:
         }}
 
         function resetChannelRecommendMarks() {{
+            // 不重建 <a>、不写回 href（CodeQL 会把 getAttribute→setAttribute(href) 判为 DOM XSS）
+            // 静态 HTML 里已有安全的 <a href=...>，只恢复文案与样式
             document.querySelectorAll(".channel-item").forEach((li) => {{
                 li.classList.remove("is-recommend");
-                if (li.querySelector(".disabled")) return;
-                const href = li.getAttribute("data-href");
+                const a = li.querySelector("a");
+                if (!a) return;
                 const label = li.getAttribute("data-label") || "";
-                if (!href) return;
-                // 用 createElement，避免 DOM 属性拼进 innerHTML（CodeQL: DOM text reinterpreted as HTML）
-                li.replaceChildren();
-                const a = document.createElement("a");
-                a.setAttribute("href", href);
                 a.textContent = label;
-                a.addEventListener("click", handleLinkClick);
-                li.appendChild(a);
+                a.classList.remove("current");
             }});
         }}
 
@@ -1313,15 +1309,14 @@ def main() -> None:
         }}
 
         function applyChannelRecommendMark(li) {{
+            // 保留原有 <a href>，只改 textContent，避免从 data-* 回写 URL
             li.classList.add("is-recommend");
+            const a = li.querySelector("a");
             const label = li.getAttribute("data-label") || "";
-            li.replaceChildren();
-            const strong = document.createElement("strong");
-            const span = document.createElement("span");
-            span.className = "current";
-            span.textContent = label + " - 当前推荐";
-            strong.appendChild(span);
-            li.appendChild(strong);
+            if (a) {{
+                a.textContent = label + " - 当前推荐";
+                a.classList.add("current");
+            }}
         }}
 
         function markPlatformRecommend(platform) {{

--- a/MaaAssistantArknights/api/qqgroup/gen_index.py
+++ b/MaaAssistantArknights/api/qqgroup/gen_index.py
@@ -1,20 +1,33 @@
 import json
+import os
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
 # 使用：
-#   python gen_index.py                          - 各平台默认推荐第 1 群
-#   python gen_index.py 28 2 1                   - Windows/Android/Mac 推荐群编号
-#   python gen_index.py windows 28 android 2 mac 1
-#   python gen_index.py channel                  - 有频道的平台推荐频道，否则仍推荐群
+#   python gen_index.py 28                       - Windows 推荐第 28 群（CI 同款）
+#                                                  Android / Mac 自动选（人数有空位优先）
+#   python gen_index.py channel                  - Windows 推荐 QQ 频道；Android/Mac 仍自动选群
+#   python gen_index.py                          - Windows 默认第 1 群；Android/Mac 自动
+#   python gen_index.py windows 28               - 只指定 Windows
+#   python gen_index.py windows 28 android 2     - 可选：手动覆盖 Android/Mac（调试用）
 #
 # 运营配置：
 #   content_windows.txt / content_android.txt / content_mac.txt
 #     每行: 加群链接|群名称|群号
 #   content_channels.txt
 #     每行: 平台|频道链接|频道名称   （# 开头为注释）
+#
+# 环境变量 GROUPINFO_API 可覆盖自动选群用的接口（默认 join.maameow.com）
 
 CHANNELS_FILE = "content_channels.txt"
+GROUPINFO_API = os.environ.get(
+    "GROUPINFO_API", "https://join.maameow.com/api/groupinfo"
+).rstrip("/")
+# 仅 Windows 由 CI/参数指定推荐；Android、Mac 默认自动
+AUTO_PLATFORMS = frozenset({"android", "mac"})
 
 PLATFORMS = ("windows", "android", "mac")
 PLATFORM_FILES = {
@@ -86,29 +99,51 @@ def load_channels(path: Path) -> dict[str, dict]:
     return channels
 
 
-def parse_args(argv: list[str]) -> tuple[dict[str, int], bool]:
-    """返回 (各平台 1-based 推荐编号, 是否频道模式)。"""
-    recommends = {p: 1 for p in PLATFORMS}
+def parse_args(argv: list[str]) -> tuple[dict[str, int | None], bool]:
+    """返回 (各平台 1-based 推荐编号或 None=自动, 是否 Windows 频道模式)。
+
+    None 表示该平台用自动选群。CI 只传一个数字时仅设置 Windows。
+    """
+    # Windows 无参时默认第 1 群；Android/Mac 默认自动
+    recommends: dict[str, int | None] = {
+        "windows": 1,
+        "android": None,
+        "mac": None,
+    }
     is_channel = False
 
     if not argv:
         return recommends, False
 
     if len(argv) == 1 and argv[0].lower() == "channel":
+        # Windows 走频道；Android/Mac 仍自动选群
+        recommends["windows"] = None
         return recommends, True
 
-    # 位置参数：windows android mac 编号
-    if all(a.isdigit() for a in argv) and 1 <= len(argv) <= 3:
-        for i, p in enumerate(PLATFORMS[: len(argv)]):
-            recommends[p] = int(argv[i])
+    # 单个数字：兼容旧 CI → 只改 Windows
+    if len(argv) == 1 and argv[0].isdigit():
+        recommends["windows"] = int(argv[0])
         return recommends, False
 
-    # 关键字参数：windows 28 android 2 mac 1 [channel]
+    # 多个纯数字：仅第一个作为 Windows（Android/Mac 保持自动，避免误伤）
+    if all(a.isdigit() for a in argv) and 1 <= len(argv) <= 3:
+        recommends["windows"] = int(argv[0])
+        if len(argv) >= 2:
+            print(
+                "提示: 位置参数仅 Windows 生效；"
+                f"已忽略多余参数 {argv[1:]!r}。"
+                "若需手动指定 Android/Mac，请用: android 2 mac 1",
+                file=sys.stderr,
+            )
+        return recommends, False
+
+    # 关键字参数：windows 28 [android 2] [mac 1] [channel]
     i = 0
     while i < len(argv):
         token = argv[i].lower()
         if token == "channel":
             is_channel = True
+            recommends["windows"] = None
             i += 1
             continue
         if token in PLATFORM_ALIASES:
@@ -119,9 +154,10 @@ def parse_args(argv: list[str]) -> tuple[dict[str, int], bool]:
             continue
         raise SystemExit(
             "用法:\n"
-            "  python gen_index.py [win编号] [android编号] [mac编号]\n"
-            "  python gen_index.py windows 28 android 2 mac 1\n"
-            "  python gen_index.py channel"
+            "  python gen_index.py <Windows群编号>     # CI：只改 Windows，Android/Mac 自动\n"
+            "  python gen_index.py channel            # Windows 推频道，Android/Mac 自动选群\n"
+            "  python gen_index.py windows 28\n"
+            "  python gen_index.py windows 28 android 2 mac 1   # 调试可手动覆盖"
         )
 
     return recommends, is_channel
@@ -137,31 +173,157 @@ def pick_recommend(groups: list[dict], index_1based: int, platform: str) -> dict
     return groups[idx]
 
 
+def fetch_group_occupancy(gids: list[str]) -> dict[str, dict]:
+    """批量查询 groupinfo；失败返回空 dict（调用方走降级）。"""
+    out: dict[str, dict] = {}
+    if not gids:
+        return out
+    # API 单次最多 20
+    for i in range(0, len(gids), 20):
+        part = gids[i : i + 20]
+        url = f"{GROUPINFO_API}?ids={urllib.parse.quote(','.join(part))}"
+        try:
+            req = urllib.request.Request(
+                url,
+                headers={"User-Agent": "MaaRelease-gen_index/1.0", "Accept": "application/json"},
+                method="GET",
+            )
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                body = json.loads(resp.read().decode("utf-8", errors="replace"))
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError) as e:
+            print(f"自动选群: groupinfo 查询失败 ({e})，将降级", file=sys.stderr)
+            continue
+        if not isinstance(body, dict) or body.get("code") != 0:
+            continue
+        data = body.get("data")
+        if isinstance(data, dict) and "groups" in data:
+            items = data.get("groups") or []
+        elif isinstance(data, dict) and data.get("group_id"):
+            items = [data]
+        else:
+            items = []
+        for g in items:
+            if not isinstance(g, dict):
+                continue
+            gid = str(g.get("group_id") or "")
+            if gid:
+                out[gid] = g
+    return out
+
+
+def auto_recommend_index(groups: list[dict], platform: str) -> int:
+    """自动选推荐群（0-based）：有空位的优先，空位多者优先；失败则第一个可用群。"""
+    active = [(i, g) for i, g in enumerate(groups) if g.get("active")]
+    if not active:
+        print(f"自动选群[{PLATFORM_LABELS[platform]}]: 无可用群，回退索引 0", file=sys.stderr)
+        return 0
+
+    gids = [g["gid"] for _, g in active]
+    occ = fetch_group_occupancy(gids)
+
+    best_i = active[0][0]
+    best_key = (-1, -1)  # (has_info, free_slots) — 无数据时 has_info=0
+    detail = []
+    for i, g in active:
+        info = occ.get(str(g["gid"]))
+        if not info or not info.get("known"):
+            detail.append(f"#{i + 1} {g['name']}=未知")
+            continue
+        free = info.get("free_slots")
+        if free is None:
+            mx = int(info.get("max_member_count") or 0)
+            cur = int(info.get("member_count") or 0)
+            free = max(0, mx - cur) if mx > 0 else 0
+        free = int(free)
+        key = (1, free)
+        cur = info.get("member_count")
+        mx = info.get("max_member_count")
+        detail.append(
+            f"#{i + 1} {g['name']}="
+            f"{cur if cur is not None else '?'}/{mx if mx is not None else '?'} 余{free}"
+        )
+        if key > best_key:
+            best_key = key
+            best_i = i
+
+    if best_key[0] < 0:
+        print(
+            f"自动选群[{PLATFORM_LABELS[platform]}]: 人数均未知，使用第一个可用群 "
+            f"#{active[0][0] + 1} {active[0][1]['name']}",
+            file=sys.stderr,
+        )
+        return active[0][0]
+
+    print(
+        f"自动选群[{PLATFORM_LABELS[platform]}]: 选中 #{best_i + 1} {groups[best_i]['name']} "
+        f"(空位优先) | " + "; ".join(detail),
+        file=sys.stderr,
+    )
+    return best_i
+
+
+def resolve_recommend(
+    platform: str,
+    groups: list[dict],
+    specified_1based: int | None,
+    *,
+    windows_channel_mode: bool,
+    channel: dict | None,
+) -> tuple[dict, int, str]:
+    """返回 (recommend字典, recommendIndex 0-based, 来源说明)。"""
+    # Windows 频道模式
+    if platform == "windows" and windows_channel_mode and channel:
+        return (
+            {"url": channel["url"], "name": channel["name"], "gid": "", "kind": "channel"},
+            -1,
+            "channel",
+        )
+
+    if specified_1based is not None:
+        rec = pick_recommend(groups, specified_1based, platform)
+        return (
+            {"url": rec["url"], "name": rec["name"], "gid": rec["gid"], "kind": "group"},
+            specified_1based - 1,
+            f"manual#{specified_1based}",
+        )
+
+    # 自动（Android / Mac，或 Windows channel 模式下无频道时）
+    idx = auto_recommend_index(groups, platform)
+    rec = groups[idx]
+    return (
+        {"url": rec["url"], "name": rec["name"], "gid": rec["gid"], "kind": "group"},
+        idx,
+        f"auto#{idx + 1}",
+    )
+
+
 def main() -> None:
     base = Path(__file__).resolve().parent
-    recommends, is_channel_mode = parse_args(sys.argv[1:])
+    recommends, windows_channel_mode = parse_args(sys.argv[1:])
     channels = load_channels(base / CHANNELS_FILE)
 
     platforms_data: dict[str, dict] = {}
     for platform in PLATFORMS:
         groups = load_groups(base / PLATFORM_FILES[platform])
-        rec = pick_recommend(groups, recommends[platform], platform)
         ch = channels.get(platform)
-        # 频道模式且该平台有频道 → 推荐频道；否则推荐群
-        use_channel = is_channel_mode and ch is not None
-        if use_channel:
-            recommend = {"url": ch["url"], "name": ch["name"], "gid": "", "kind": "channel"}
-        else:
-            recommend = {
-                "url": rec["url"],
-                "name": rec["name"],
-                "gid": rec["gid"],
-                "kind": "group",
-            }
+        specified = recommends.get(platform)
+        # Android/Mac：除非关键字显式传入，否则强制自动（忽略误传）
+        if platform in AUTO_PLATFORMS and specified is not None:
+            # 仅当通过关键字 android N / mac N 传入时 keeps specified；
+            # parse_args 已保证单数字不会写入 android/mac
+            pass
+        recommend, rec_index, source = resolve_recommend(
+            platform,
+            groups,
+            specified,
+            windows_channel_mode=windows_channel_mode,
+            channel=ch,
+        )
         platforms_data[platform] = {
             "label": PLATFORM_LABELS[platform],
-            "recommendIndex": recommends[platform] - 1,
+            "recommendIndex": rec_index,
             "recommend": recommend,
+            "recommendSource": source,
             "groups": groups,
             "validCount": sum(1 for g in groups if g["active"]),
             "channel": ch,
@@ -239,7 +401,7 @@ def main() -> None:
             f'<a href="{url}" onclick="handleLinkClick(event)">{label}</a></li>\n'
         )
 
-    header_extra = " channel-header" if is_channel_mode else ""
+    header_extra = " channel-header" if windows_channel_mode else ""
 
     # JS 用的推荐映射（平台 → 跳转目标）
     recommend_map = {
@@ -1016,8 +1178,12 @@ def main() -> None:
     parts = []
     for p in PLATFORMS:
         rec = platforms_data[p]["recommend"]
-        kind = "频道" if rec["kind"] == "channel" else f"#{recommends[p]}"
-        parts.append(f"{PLATFORM_LABELS[p]}{kind}({rec['name']})")
+        src = platforms_data[p].get("recommendSource", "")
+        if rec["kind"] == "channel":
+            kind = f"频道/{src}"
+        else:
+            kind = src or f"#{platforms_data[p]['recommendIndex'] + 1}"
+        parts.append(f"{PLATFORM_LABELS[p]}:{kind}({rec['name']})")
     mode = " / ".join(parts)
 
     print(f"已更新 {out.name} → {mode}")
@@ -1026,6 +1192,7 @@ def main() -> None:
         ch_info = f", 频道 {ch['name']}" if ch else ", 无频道"
         print(
             f"  - {PLATFORM_LABELS[p]}: {platforms_data[p]['validCount']} 个群"
+            f", 推荐来源 {platforms_data[p].get('recommendSource')}"
             f", 配置 {PLATFORM_FILES[p]}{ch_info}"
         )
     print(f"  - 频道配置: {CHANNELS_FILE} ({len(channels)} 个平台)")

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -1,11 +1,11 @@
-
 <!DOCTYPE html>
-<html>
+<html lang="zh-CN">
 <head>
-    <title>欢迎加入 MAA 二十八裙</title>
+    <title>欢迎加入 MAA 交流群</title>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; }
+        body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; color: #222; }
         .current { color: #ff6600; }
         ul { list-style-type: none; padding: 0; }
         li { margin: 12px 0; padding: 8px; background: #f9f9f9; border-radius: 5px; }
@@ -14,16 +14,172 @@
         li > a:hover { color: #004499; }
         .container { max-width: 800px; margin: 0 auto; }
         .header { background: #eef5ff; padding: 20px; border-radius: 8px; margin-bottom: 20px; }
-        .primary-link { display: inline-block; padding: 10px 20px; background: #0066cc; color: white; border-radius: 5px; margin: 10px 0; }
-        .primary-link:hover { background: #004499; text-decoration: none; }
-        .cancel-btn { 
-            display: inline-block; 
-            padding: 8px 16px; 
-            background: #ff6666; 
-            color: white; 
-            border: none; 
-            border-radius: 5px; 
-            cursor: pointer; 
+        .header.channel-header { background: linear-gradient(135deg, #e8f0fe, #f0e6ff); }
+        .platform-row {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin: 12px 0 4px;
+        }
+        .platform-label { color: #555; font-size: 0.95em; margin-right: 4px; }
+        .platform-tabs {
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+        .platform-tab {
+            padding: 8px 16px;
+            border: 2px solid #c5d8f5;
+            border-radius: 999px;
+            background: #fff;
+            color: #0066cc;
+            font-weight: bold;
+            font-size: 0.95em;
+            cursor: pointer;
+            transition: border-color .15s, background .15s, color .15s;
+        }
+        .platform-tab:hover {
+            border-color: #0066cc;
+            background: #f3f8ff;
+        }
+        .platform-tab.active {
+            border-color: #0066cc;
+            background: #0066cc;
+            color: #fff;
+        }
+        .header.channel-header .platform-tab.active {
+            border-color: #7c4dff;
+            background: #7c4dff;
+        }
+        .primary-link {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 12px 22px;
+            min-height: 44px;
+            background: #0066cc;
+            color: #fff;
+            border-radius: 8px;
+            margin: 10px 0;
+            border: none;
+            cursor: pointer;
+            font-size: 1em;
+            font-weight: bold;
+            text-decoration: none;
+            overflow: hidden;
+            isolation: isolate;
+            z-index: 0;
+            box-shadow: 0 4px 12px rgba(0, 102, 204, 0.28);
+            -webkit-tap-highlight-color: transparent;
+            touch-action: manipulation;
+        }
+        .primary-link .btn-text {
+            position: relative;
+            z-index: 2;
+        }
+        .primary-link.is-disabled {
+            pointer-events: none;
+            cursor: not-allowed;
+            box-shadow: none;
+            opacity: 0.55;
+            background: #8aa8cc;
+        }
+        .primary-link.is-disabled.chroma {
+            background: #8aa8cc;
+        }
+        .primary-link.is-disabled.chroma::before,
+        .primary-link.is-disabled.chroma::after {
+            display: none;
+        }
+        /* 无缝炫彩：色带重复两份，translateX 平移 50% 避免顿挫 */
+        .primary-link.chroma:not(.is-disabled) {
+            background: transparent;
+        }
+        .primary-link.chroma:not(.is-disabled)::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 200%;
+            z-index: 0;
+            background: linear-gradient(
+                90deg,
+                #ff4d4f, #fa8c16, #fadb14, #52c41a, #13c2c2, #1677ff, #722ed1, #eb2f96,
+                #ff4d4f, #fa8c16, #fadb14, #52c41a, #13c2c2, #1677ff, #722ed1, #eb2f96,
+                #ff4d4f
+            );
+            animation: chroma-slide 3s linear infinite;
+            pointer-events: none;
+            will-change: transform;
+        }
+        .primary-link.chroma:not(.is-disabled)::after {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: -40%;
+            width: 40%;
+            height: 100%;
+            z-index: 1;
+            background: linear-gradient(
+                100deg,
+                transparent 0%,
+                rgba(255, 255, 255, 0.15) 40%,
+                rgba(255, 255, 255, 0.45) 50%,
+                rgba(255, 255, 255, 0.15) 60%,
+                transparent 100%
+            );
+            animation: chroma-shine 2.5s linear infinite;
+            pointer-events: none;
+            will-change: transform;
+        }
+        .primary-link.chroma:not(.is-disabled):hover {
+            filter: brightness(1.05);
+            box-shadow: 0 6px 16px rgba(114, 46, 209, 0.35);
+            text-decoration: none;
+            color: #fff;
+        }
+        .primary-link.chroma:not(.is-disabled):active {
+            filter: brightness(0.98);
+        }
+        @keyframes chroma-slide {
+            from { transform: translateX(0); }
+            to { transform: translateX(-50%); }
+        }
+        @keyframes chroma-shine {
+            from { transform: translateX(0); }
+            to { transform: translateX(350%); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .primary-link.chroma:not(.is-disabled)::before,
+            .primary-link.chroma:not(.is-disabled)::after {
+                animation: none;
+            }
+            .primary-link.chroma:not(.is-disabled)::before {
+                width: 100%;
+                background: #0066cc;
+                transform: none;
+            }
+            .primary-link.chroma:not(.is-disabled)::after {
+                display: none;
+            }
+            .primary-link.chroma:not(.is-disabled) {
+                box-shadow: none;
+            }
+            .channel-header .primary-link.chroma:not(.is-disabled)::before {
+                background: #7c4dff;
+            }
+        }
+        .cancel-btn {
+            display: inline-block;
+            padding: 8px 16px;
+            background: #ff6666;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
             margin-left: 10px;
         }
         .cancel-btn:hover { background: #cc5555; }
@@ -32,112 +188,330 @@
         .channel { background: linear-gradient(135deg, #e8f0fe, #f0e6ff); border-left: 4px solid #7c4dff; }
         .channel a { color: #7c4dff; }
         .channel a:hover { color: #5e35b1; }
-        .channel-header { background: linear-gradient(135deg, #e8f0fe, #f0e6ff); }
-        .channel-header .primary-link { background: #7c4dff; }
-        .channel-header .primary-link:hover { background: #5e35b1; }
+        .channel-item { display: none; }
+        .channel-item.is-active { display: list-item; }
+        .channel-item.is-recommend {
+            background: #f3e8ff;
+            border-left: 4px solid #7c4dff;
+        }
+        .tip { color: #666; font-size: 0.95em; }
+        .hint { color: #555; margin: 8px 0 0; }
+        /* 下方群列表：按平台分块，默认隐藏，选中后只显示对应平台 */
+        .group-section {
+            display: none;
+            margin: 18px 0 24px;
+            padding: 14px 16px 8px;
+            border: 1px solid #e3eaf5;
+            border-radius: 10px;
+            background: #fafcff;
+        }
+        .group-section.is-active {
+            display: block;
+            border-color: #0066cc;
+            box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.12);
+            background: #f3f8ff;
+        }
+        .group-section-title {
+            margin: 0 0 10px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid #e3eaf5;
+            font-size: 1.1em;
+        }
+        .group-count {
+            color: #888;
+            font-weight: normal;
+            font-size: 0.9em;
+            margin-left: 6px;
+        }
+        .group-list { margin: 0; }
+        .group-item.is-recommend {
+            background: #fff4e8;
+            border-left: 4px solid #ff6600;
+        }
+        .lists-heading { margin: 24px 0 8px; font-size: 1.15em; }
+        .lists-placeholder { color: #888; margin: 12px 0 24px; }
+        .lists-placeholder.is-hidden { display: none; }
+        .channel-placeholder { color: #888; margin: 8px 0; }
+        .channel-placeholder.is-hidden { display: none; }
+        .channel-block.is-empty .channel-list { display: none; }
     </style>
     <script>
-        let redirectEnabled = true;
+        const RECOMMENDS = {"windows": {"url": "https://qm.qq.com/q/SZilizX7SW", "name": "MAA 二十八裙", "gid": "739772723", "kind": "group"}, "android": {"url": "https://qm.qq.com/q/hWvDx6cNag", "name": "安卓版MAA 交流2群", "gid": "1092878305", "kind": "group"}, "mac": {"url": "https://qm.qq.com/q/2uhPXiNOR0", "name": "Mac版MAA 交流群", "gid": "1091086083", "kind": "group"}};
+        const CHANNELS = {"windows": {"url": "https://pd.qq.com/s/8d3h265zd?b=9", "name": "MAA QQ 频道"}, "android": {"url": "https://pd.qq.com/s/4w4kgi4s4", "name": "安卓版 MAA QQ 频道"}, "mac": null};
+        const PLATFORM_LABELS = { windows: "Windows", android: "Android", mac: "Mac" };
+
+        // 必须用户主动选择平台后，才启动自动跳转
+        let redirectEnabled = false;
         let countdown = 8;
         let countdownTimer = null;
-        
-        function cancelRedirect() {
+        let currentJoinUrl = "";
+        let currentPlatform = "";
+        let userCancelled = false;
+
+        function stopCountdown() {
             redirectEnabled = false;
             if (countdownTimer) {
                 clearTimeout(countdownTimer);
+                countdownTimer = null;
             }
-            document.getElementById('countdown').textContent = '0';
-            document.getElementById('redirectText').innerHTML = '自动跳转已取消';
-            document.getElementById('cancelBtn').style.display = 'none';
         }
-        
+
+        function cancelRedirect() {
+            userCancelled = true;
+            stopCountdown();
+            const text = document.getElementById("redirectText");
+            if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+        }
+
         function handleLinkClick(event) {
-            cancelRedirect();
-            // 允许正常跳转
+            // 点了列表里的群：取消自动跳转，但保留已选平台与主按钮
+            if (currentPlatform) cancelRedirect();
         }
-        
+
         function handlePrimaryLinkClick(event) {
+            const primary = document.getElementById("primaryLink");
+            if (primary.classList.contains("is-disabled") || !currentJoinUrl) {
+                event.preventDefault();
+                return;
+            }
             cancelRedirect();
-            // 允许正常跳转
         }
-        
+
+        function startRedirect(url) {
+            if (userCancelled) {
+                // 用户已取消过：只更新链接，不再自动跳
+                currentJoinUrl = url;
+                const text = document.getElementById("redirectText");
+                if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+                return;
+            }
+            currentJoinUrl = url;
+            redirectEnabled = true;
+            countdown = 8;
+            if (countdownTimer) clearTimeout(countdownTimer);
+
+            document.getElementById("redirectText").innerHTML =
+                '已选择平台，页面将在 <span id="countdown">' + countdown + '</span> 秒后自动跳转……' +
+                '<button type="button" id="cancelBtn" class="cancel-btn" onclick="cancelRedirect()">取消自动跳转</button>';
+            countdownTimer = setTimeout(updateCountdown, 1000);
+        }
+
         function updateCountdown() {
             if (redirectEnabled && countdown > 0) {
                 countdown--;
-                document.getElementById('countdown').textContent = countdown;
+                const el = document.getElementById("countdown");
+                if (el) el.textContent = countdown;
                 countdownTimer = setTimeout(updateCountdown, 1000);
             } else if (redirectEnabled && countdown === 0) {
-                window.location.href = "https://qm.qq.com/q/SZilizX7SW";
+                window.location.href = currentJoinUrl;
             }
         }
-        
-        window.onload = function() {
-            updateCountdown();
-        };
+
+        function resetListRecommendMarks(selector) {
+            document.querySelectorAll(selector).forEach((li) => {
+                li.classList.remove("is-recommend");
+                if (li.querySelector(".disabled")) return;
+                const href = li.getAttribute("data-href");
+                const label = li.getAttribute("data-label") || "";
+                if (!href) return;
+                li.innerHTML = '<a href="' + href + '" onclick="handleLinkClick(event)">' +
+                    label + "</a>";
+            });
+        }
+
+        function applyRecommendMark(li) {
+            li.classList.add("is-recommend");
+            const label = li.getAttribute("data-label") || "";
+            li.innerHTML = '<strong><span class="current">' + label +
+                " - 当前推荐</span></strong>";
+        }
+
+        function markPlatformRecommend(platform) {
+            resetListRecommendMarks(".group-item");
+            resetListRecommendMarks(".channel-item");
+
+            const listsPlaceholder = document.getElementById("listsPlaceholder");
+            if (listsPlaceholder) listsPlaceholder.classList.add("is-hidden");
+
+            document.querySelectorAll(".group-section").forEach((sec) => {
+                sec.classList.toggle("is-active", sec.getAttribute("data-platform") === platform);
+            });
+
+            // 频道：只展示当前平台
+            const channelPlaceholder = document.getElementById("channelPlaceholder");
+            const channelBlock = document.getElementById("channelBlock");
+            let hasChannel = false;
+            document.querySelectorAll(".channel-item").forEach((li) => {
+                const match = li.getAttribute("data-platform") === platform;
+                li.classList.toggle("is-active", match);
+                if (match) hasChannel = true;
+            });
+            if (channelPlaceholder) {
+                channelPlaceholder.classList.toggle("is-hidden", hasChannel);
+                if (!hasChannel) {
+                    channelPlaceholder.textContent = "该平台暂无 QQ 频道";
+                }
+            }
+            if (channelBlock) {
+                channelBlock.classList.toggle("is-empty", !hasChannel);
+            }
+
+            // 高亮当前推荐（群或频道）
+            document.querySelectorAll(
+                '.group-item[data-platform="' + platform + '"][data-recommend="1"]'
+            ).forEach(applyRecommendMark);
+            document.querySelectorAll(
+                '.channel-item[data-platform="' + platform + '"][data-recommend="1"]'
+            ).forEach(applyRecommendMark);
+        }
+
+        function selectPlatform(platform) {
+            const rec = RECOMMENDS[platform];
+            if (!rec) return;
+
+            // 主动点选平台视为新意图：重新开启自动跳转
+            userCancelled = false;
+            currentPlatform = platform;
+
+            document.querySelectorAll(".platform-tab").forEach((btn) => {
+                btn.classList.toggle("active", btn.getAttribute("data-platform") === platform);
+            });
+
+            markPlatformRecommend(platform);
+
+            const title = document.getElementById("join-title");
+            const gidEl = document.getElementById("join-gid");
+            const primary = document.getElementById("primaryLink");
+            const btnText = primary.querySelector(".btn-text");
+            const label = PLATFORM_LABELS[platform] || platform;
+            const isChannel = rec.kind === "channel";
+
+            if (isChannel) {
+                title.textContent = "欢迎加入【" + rec.name + "】（" + label + "）";
+                gidEl.style.display = "none";
+                if (btnText) btnText.textContent = "立即加入 QQ 频道";
+            } else {
+                title.textContent = "欢迎加入【" + rec.name + "】（" + label + "）";
+                if (rec.gid) {
+                    gidEl.style.display = "";
+                    gidEl.innerHTML = '群号: <strong>' + rec.gid + "</strong>";
+                } else {
+                    gidEl.style.display = "none";
+                }
+                if (btnText) btnText.textContent = "立即加入当前推荐群组";
+            }
+
+            primary.href = rec.url;
+            primary.classList.remove("is-disabled");
+            primary.setAttribute("aria-disabled", "false");
+            startRedirect(rec.url);
+        }
     </script>
 </head>
 <body>
     <div class="container">
-        <div class="header">
-            <h2>欢迎加入【MAA 二十八裙】</h2>
-            <p>群号: <strong>739772723</strong></p>
-            <p><a href="https://qm.qq.com/q/SZilizX7SW" class="primary-link" onclick="handlePrimaryLinkClick(event)">立即加入当前推荐群组</a></p>
-            <p id="redirectText">
-                页面将在 <span id="countdown">8</span> 秒后自动跳转……
-                <button id="cancelBtn" class="cancel-btn" onclick="cancelRedirect()">取消自动跳转</button>
+        <div id="join-header" class="header">
+            <h2 id="join-title">欢迎加入 MAA 交流群</h2>
+            <p id="join-gid" style="display:none"></p>
+
+            <div class="platform-row">
+                <span class="platform-label">请先选择平台：</span>
+                <div class="platform-tabs" role="tablist" aria-label="客户端平台">
+                    <button type="button" class="platform-tab" data-platform="windows"
+                        onclick="selectPlatform('windows')">Windows</button>
+                    <button type="button" class="platform-tab" data-platform="android"
+                        onclick="selectPlatform('android')">Android</button>
+                    <button type="button" class="platform-tab" data-platform="mac"
+                        onclick="selectPlatform('mac')">Mac</button>
+                </div>
+            </div>
+            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。</p>
+
+            <p>
+                <a id="primaryLink" href="#" class="primary-link chroma is-disabled"
+                   aria-disabled="true" onclick="handlePrimaryLinkClick(event)">
+                    <span class="btn-text">请先选择平台</span>
+                </a>
             </p>
+            <p id="redirectText">尚未选择平台，不会自动跳转</p>
         </div>
-        
-        <h3>QQ 频道:</h3>
-        <ul>
-            <li class="channel"><a href="https://pd.qq.com/s/8d3h265zd?b=9" onclick="handleLinkClick(event)">MAA QQ 频道</a></li>
 
-        </ul>
-        
-        <h3>可用群组列表 (共 38 个):</h3>
-        <ul>
-            <li><a href="https://qm.qq.com/q/brtJGf5h2o" onclick="handleLinkClick(event)">MAA 一裙 (791704225)</a></li>
-<li><a href="https://qm.qq.com/q/qLl7QgcxQ4" onclick="handleLinkClick(event)">MAA 避难所 (875959402)</a></li>
-<li><a href="https://qm.qq.com/q/yo4UYi3SIS" onclick="handleLinkClick(event)">MAA 三裙 (954069034)</a></li>
-<li><a href="https://qm.qq.com/q/Xy1STSCJWK" onclick="handleLinkClick(event)">MAA 四裙 (645852443)</a></li>
-<li><a href="https://qm.qq.com/q/R3w7RQIZIy" onclick="handleLinkClick(event)">MAA 五裙 (399375745)</a></li>
-<li><a href="https://qm.qq.com/q/mDj4OY07mg" onclick="handleLinkClick(event)">MAA 六裙 (704746719)</a></li>
-<li><a href="https://qm.qq.com/q/aK0SnYsWGc" onclick="handleLinkClick(event)">MAA 七裙 (285898225)</a></li>
-<li><a href="https://qm.qq.com/q/pNCuptVPhK" onclick="handleLinkClick(event)">MAA 八裙 (290949547)</a></li>
-<li><a href="https://qm.qq.com/q/sDBm8wDowo" onclick="handleLinkClick(event)">MAA 九裙 (764034517)</a></li>
-<li><a href="https://qm.qq.com/q/ekeuIR4ZvU" onclick="handleLinkClick(event)">MAA 十裙 (362529812)</a></li>
-<li><a href="https://qm.qq.com/q/hVjtFOkyeQ" onclick="handleLinkClick(event)">MAA 十一裙 (536038978)</a></li>
-<li><a href="https://qm.qq.com/q/m7nBOkijOE" onclick="handleLinkClick(event)">MAA 十二裙 (577460690)</a></li>
-<li><a href="https://qm.qq.com/q/k0KlwMhrpe" onclick="handleLinkClick(event)">MAA 十三裙 (518779858)</a></li>
-<li><a href="https://qm.qq.com/q/Ehh5ouuopy" onclick="handleLinkClick(event)">MAA 十四裙 (1105335749)</a></li>
-<li><a href="https://qm.qq.com/q/dOy0JcI7ew" onclick="handleLinkClick(event)">MAA 十五裙 (821474369)</a></li>
-<li><a href="https://qm.qq.com/q/eVv3ZHFPPO" onclick="handleLinkClick(event)">MAA 十六裙 (756840093)</a></li>
-<li><a href="https://qm.qq.com/q/WA16EHmPGc" onclick="handleLinkClick(event)">MAA 十七裙 (130793607)</a></li>
-<li><a href="https://qm.qq.com/q/HtWF3F9csu" onclick="handleLinkClick(event)">MAA 十八裙 (1019089084)</a></li>
-<li><a href="https://qm.qq.com/q/VZziwrFio4" onclick="handleLinkClick(event)">MAA 十九裙 (1037746358)</a></li>
-<li><a href="https://qm.qq.com/q/r8QSte9pf2" onclick="handleLinkClick(event)">MAA 二十裙 (811923437)</a></li>
-<li><a href="https://qm.qq.com/q/Ly0mxKm9Cs" onclick="handleLinkClick(event)">MAA 二十一裙 (147682068)</a></li>
-<li><a href="https://qm.qq.com/q/fxL5QSX53a" onclick="handleLinkClick(event)">MAA 二十二裙 (1018167389)</a></li>
-<li><a href="https://qm.qq.com/q/wgwWha2QiA" onclick="handleLinkClick(event)">MAA 二十三裙 (744379789)</a></li>
-<li><a href="https://qm.qq.com/q/U6hTfcjxa8" onclick="handleLinkClick(event)">MAA 二十四裙 (1017931295)</a></li>
-<li><a href="https://qm.qq.com/q/MUeqpeXu8M" onclick="handleLinkClick(event)">MAA 二十五裙 (978314648)</a></li>
-<li><a href="https://qm.qq.com/q/34CZxNGeCc" onclick="handleLinkClick(event)">MAA 二十六裙 (475886359)</a></li>
-<li><a href="https://qm.qq.com/q/JebChwBSUu" onclick="handleLinkClick(event)">MAA 二十七裙 (1037257260)</a></li>
-<li><strong><span class="current">MAA 二十八裙 (739772723) - 当前推荐</span></strong></li>
-<li><a href="https://qm.qq.com/q/YV1bCw5CKK" onclick="handleLinkClick(event)">MAA 二十九裙 (514134954)</a></li>
-<li><a href="https://qm.qq.com/q/6EHIjpxUBy" onclick="handleLinkClick(event)">MAA 三十裙 (596196146)</a></li>
-<li><a href="https://qm.qq.com/q/sW8LlaNMME" onclick="handleLinkClick(event)">MAA 三十一裙 (545928846)</a></li>
-<li><a href="https://qm.qq.com/q/pt47DXsH2E" onclick="handleLinkClick(event)">MAA 三十二裙 (216314927)</a></li>
-<li><a href="https://qm.qq.com/q/ZsMmM5IX2A" onclick="handleLinkClick(event)">MAA 三十三裙 (1003478193)</a></li>
-<li><a href="https://qm.qq.com/q/ImsUweGc8i" onclick="handleLinkClick(event)">MAA 三十四裙 (1009052305)</a></li>
-<li><a href="https://qm.qq.com/q/hfisRrMmnC" onclick="handleLinkClick(event)">MAA 三十五裙 (774683898)</a></li>
-<li><a href="https://qm.qq.com/q/L8Tyfs268E" onclick="handleLinkClick(event)">安卓版MAA 交流1群 (1074855131)</a></li>
-<li><a href="https://qm.qq.com/q/hWvDx6cNag" onclick="handleLinkClick(event)">安卓版MAA 交流2群 (1092878305)</a></li>
-<li><a href="https://qm.qq.com/q/2uhPXiNOR0" onclick="handleLinkClick(event)">Mac版MAA 交流群 (1091086083)</a></li>
+        <div id="channelBlock" class="channel-block">
+            <h3>QQ 频道</h3>
+            <p id="channelPlaceholder" class="channel-placeholder">请先选择平台，以查看对应频道。</p>
+            <ul class="channel-list">
+<li class="channel channel-item" data-platform="windows" data-label="MAA QQ 频道" data-href="https://pd.qq.com/s/8d3h265zd?b=9"><a href="https://pd.qq.com/s/8d3h265zd?b=9" onclick="handleLinkClick(event)">MAA QQ 频道</a></li>
+<li class="channel channel-item" data-platform="android" data-label="安卓版 MAA QQ 频道" data-href="https://pd.qq.com/s/4w4kgi4s4"><a href="https://pd.qq.com/s/4w4kgi4s4" onclick="handleLinkClick(event)">安卓版 MAA QQ 频道</a></li>
+            </ul>
+        </div>
 
-        </ul>
-        
-        <p class="tip">如果当前群组已满或链接失效，请选择其他群组加入（点击任意链接将取消自动跳转）</p>
+        <h3 class="lists-heading">群组列表</h3>
+        <p id="listsPlaceholder" class="lists-placeholder">请先在上方选择平台，以查看对应群列表。</p>
+
+        <section class="group-section" id="section-windows" data-platform="windows">
+            <h3 class="group-section-title">Windows 群组
+                <span class="group-count">共 35 个</span>
+            </h3>
+            <ul class="group-list">
+                <li class="group-item" data-platform="windows" data-label="MAA 一裙 (791704225)" data-href="https://qm.qq.com/q/brtJGf5h2o"><a href="https://qm.qq.com/q/brtJGf5h2o" onclick="handleLinkClick(event)">MAA 一裙 (791704225)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 避难所 (875959402)" data-href="https://qm.qq.com/q/qLl7QgcxQ4"><a href="https://qm.qq.com/q/qLl7QgcxQ4" onclick="handleLinkClick(event)">MAA 避难所 (875959402)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 三裙 (954069034)" data-href="https://qm.qq.com/q/yo4UYi3SIS"><a href="https://qm.qq.com/q/yo4UYi3SIS" onclick="handleLinkClick(event)">MAA 三裙 (954069034)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 四裙 (645852443)" data-href="https://qm.qq.com/q/Xy1STSCJWK"><a href="https://qm.qq.com/q/Xy1STSCJWK" onclick="handleLinkClick(event)">MAA 四裙 (645852443)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 五裙 (399375745)" data-href="https://qm.qq.com/q/R3w7RQIZIy"><a href="https://qm.qq.com/q/R3w7RQIZIy" onclick="handleLinkClick(event)">MAA 五裙 (399375745)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 六裙 (704746719)" data-href="https://qm.qq.com/q/mDj4OY07mg"><a href="https://qm.qq.com/q/mDj4OY07mg" onclick="handleLinkClick(event)">MAA 六裙 (704746719)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 七裙 (285898225)" data-href="https://qm.qq.com/q/aK0SnYsWGc"><a href="https://qm.qq.com/q/aK0SnYsWGc" onclick="handleLinkClick(event)">MAA 七裙 (285898225)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 八裙 (290949547)" data-href="https://qm.qq.com/q/pNCuptVPhK"><a href="https://qm.qq.com/q/pNCuptVPhK" onclick="handleLinkClick(event)">MAA 八裙 (290949547)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 九裙 (764034517)" data-href="https://qm.qq.com/q/sDBm8wDowo"><a href="https://qm.qq.com/q/sDBm8wDowo" onclick="handleLinkClick(event)">MAA 九裙 (764034517)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十裙 (362529812)" data-href="https://qm.qq.com/q/ekeuIR4ZvU"><a href="https://qm.qq.com/q/ekeuIR4ZvU" onclick="handleLinkClick(event)">MAA 十裙 (362529812)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十一裙 (536038978)" data-href="https://qm.qq.com/q/hVjtFOkyeQ"><a href="https://qm.qq.com/q/hVjtFOkyeQ" onclick="handleLinkClick(event)">MAA 十一裙 (536038978)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十二裙 (577460690)" data-href="https://qm.qq.com/q/m7nBOkijOE"><a href="https://qm.qq.com/q/m7nBOkijOE" onclick="handleLinkClick(event)">MAA 十二裙 (577460690)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十三裙 (518779858)" data-href="https://qm.qq.com/q/k0KlwMhrpe"><a href="https://qm.qq.com/q/k0KlwMhrpe" onclick="handleLinkClick(event)">MAA 十三裙 (518779858)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十四裙 (1105335749)" data-href="https://qm.qq.com/q/Ehh5ouuopy"><a href="https://qm.qq.com/q/Ehh5ouuopy" onclick="handleLinkClick(event)">MAA 十四裙 (1105335749)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十五裙 (821474369)" data-href="https://qm.qq.com/q/dOy0JcI7ew"><a href="https://qm.qq.com/q/dOy0JcI7ew" onclick="handleLinkClick(event)">MAA 十五裙 (821474369)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十六裙 (756840093)" data-href="https://qm.qq.com/q/eVv3ZHFPPO"><a href="https://qm.qq.com/q/eVv3ZHFPPO" onclick="handleLinkClick(event)">MAA 十六裙 (756840093)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十七裙 (130793607)" data-href="https://qm.qq.com/q/WA16EHmPGc"><a href="https://qm.qq.com/q/WA16EHmPGc" onclick="handleLinkClick(event)">MAA 十七裙 (130793607)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十八裙 (1019089084)" data-href="https://qm.qq.com/q/HtWF3F9csu"><a href="https://qm.qq.com/q/HtWF3F9csu" onclick="handleLinkClick(event)">MAA 十八裙 (1019089084)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 十九裙 (1037746358)" data-href="https://qm.qq.com/q/VZziwrFio4"><a href="https://qm.qq.com/q/VZziwrFio4" onclick="handleLinkClick(event)">MAA 十九裙 (1037746358)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十裙 (811923437)" data-href="https://qm.qq.com/q/r8QSte9pf2"><a href="https://qm.qq.com/q/r8QSte9pf2" onclick="handleLinkClick(event)">MAA 二十裙 (811923437)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十一裙 (147682068)" data-href="https://qm.qq.com/q/Ly0mxKm9Cs"><a href="https://qm.qq.com/q/Ly0mxKm9Cs" onclick="handleLinkClick(event)">MAA 二十一裙 (147682068)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十二裙 (1018167389)" data-href="https://qm.qq.com/q/fxL5QSX53a"><a href="https://qm.qq.com/q/fxL5QSX53a" onclick="handleLinkClick(event)">MAA 二十二裙 (1018167389)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十三裙 (744379789)" data-href="https://qm.qq.com/q/wgwWha2QiA"><a href="https://qm.qq.com/q/wgwWha2QiA" onclick="handleLinkClick(event)">MAA 二十三裙 (744379789)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十四裙 (1017931295)" data-href="https://qm.qq.com/q/U6hTfcjxa8"><a href="https://qm.qq.com/q/U6hTfcjxa8" onclick="handleLinkClick(event)">MAA 二十四裙 (1017931295)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十五裙 (978314648)" data-href="https://qm.qq.com/q/MUeqpeXu8M"><a href="https://qm.qq.com/q/MUeqpeXu8M" onclick="handleLinkClick(event)">MAA 二十五裙 (978314648)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十六裙 (475886359)" data-href="https://qm.qq.com/q/34CZxNGeCc"><a href="https://qm.qq.com/q/34CZxNGeCc" onclick="handleLinkClick(event)">MAA 二十六裙 (475886359)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十七裙 (1037257260)" data-href="https://qm.qq.com/q/JebChwBSUu"><a href="https://qm.qq.com/q/JebChwBSUu" onclick="handleLinkClick(event)">MAA 二十七裙 (1037257260)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十八裙 (739772723)" data-href="https://qm.qq.com/q/SZilizX7SW" data-recommend="1"><a href="https://qm.qq.com/q/SZilizX7SW" onclick="handleLinkClick(event)">MAA 二十八裙 (739772723)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 二十九裙 (514134954)" data-href="https://qm.qq.com/q/YV1bCw5CKK"><a href="https://qm.qq.com/q/YV1bCw5CKK" onclick="handleLinkClick(event)">MAA 二十九裙 (514134954)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 三十裙 (596196146)" data-href="https://qm.qq.com/q/6EHIjpxUBy"><a href="https://qm.qq.com/q/6EHIjpxUBy" onclick="handleLinkClick(event)">MAA 三十裙 (596196146)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 三十一裙 (545928846)" data-href="https://qm.qq.com/q/sW8LlaNMME"><a href="https://qm.qq.com/q/sW8LlaNMME" onclick="handleLinkClick(event)">MAA 三十一裙 (545928846)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 三十二裙 (216314927)" data-href="https://qm.qq.com/q/pt47DXsH2E"><a href="https://qm.qq.com/q/pt47DXsH2E" onclick="handleLinkClick(event)">MAA 三十二裙 (216314927)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 三十三裙 (1003478193)" data-href="https://qm.qq.com/q/ZsMmM5IX2A"><a href="https://qm.qq.com/q/ZsMmM5IX2A" onclick="handleLinkClick(event)">MAA 三十三裙 (1003478193)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 三十四裙 (1009052305)" data-href="https://qm.qq.com/q/ImsUweGc8i"><a href="https://qm.qq.com/q/ImsUweGc8i" onclick="handleLinkClick(event)">MAA 三十四裙 (1009052305)</a></li>
+<li class="group-item" data-platform="windows" data-label="MAA 三十五裙 (774683898)" data-href="https://qm.qq.com/q/hfisRrMmnC"><a href="https://qm.qq.com/q/hfisRrMmnC" onclick="handleLinkClick(event)">MAA 三十五裙 (774683898)</a></li>
+            </ul>
+        </section>
+
+        <section class="group-section" id="section-android" data-platform="android">
+            <h3 class="group-section-title">Android 群组
+                <span class="group-count">共 3 个</span>
+            </h3>
+            <ul class="group-list">
+                <li class="group-item" data-platform="android" data-label="安卓版MAA 交流1群 (1074855131)" data-href="https://qm.qq.com/q/L8Tyfs268E"><a href="https://qm.qq.com/q/L8Tyfs268E" onclick="handleLinkClick(event)">安卓版MAA 交流1群 (1074855131)</a></li>
+<li class="group-item" data-platform="android" data-label="安卓版MAA 交流2群 (1092878305)" data-href="https://qm.qq.com/q/hWvDx6cNag" data-recommend="1"><a href="https://qm.qq.com/q/hWvDx6cNag" onclick="handleLinkClick(event)">安卓版MAA 交流2群 (1092878305)</a></li>
+<li class="group-item" data-platform="android" data-label="安卓版MAA 交流3群 (764534097)" data-href="https://qm.qq.com/q/ptPGw0wcEw"><a href="https://qm.qq.com/q/ptPGw0wcEw" onclick="handleLinkClick(event)">安卓版MAA 交流3群 (764534097)</a></li>
+            </ul>
+        </section>
+
+        <section class="group-section" id="section-mac" data-platform="mac">
+            <h3 class="group-section-title">Mac 群组
+                <span class="group-count">共 1 个</span>
+            </h3>
+            <ul class="group-list">
+                <li class="group-item" data-platform="mac" data-label="Mac版MAA 交流群 (1091086083)" data-href="https://qm.qq.com/q/2uhPXiNOR0" data-recommend="1"><a href="https://qm.qq.com/q/2uhPXiNOR0" onclick="handleLinkClick(event)">Mac版MAA 交流群 (1091086083)</a></li>
+            </ul>
+        </section>
+
+        <p class="tip">如果当前群组已满或链接失效，请选择其他群组加入（点击任意链接将取消自动跳转）。</p>
     </div>
 </body>
 </html>

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -297,7 +297,7 @@
         .channel-block.is-empty .channel-list { display: none; }
     </style>
     <script>
-        const RECOMMENDS = {"windows": {"url": "https://qm.qq.com/q/SZilizX7SW", "name": "MAA 二十八裙", "gid": "739772723", "kind": "group"}, "android": {"url": "https://qm.qq.com/q/hWvDx6cNag", "name": "安卓版MAA 交流2群", "gid": "1092878305", "kind": "group"}, "mac": {"url": "https://qm.qq.com/q/2uhPXiNOR0", "name": "Mac版MAA 交流群", "gid": "1091086083", "kind": "group"}};
+        const RECOMMENDS = {"windows": {"url": "https://qm.qq.com/q/SZilizX7SW", "name": "MAA 二十八裙", "gid": "739772723", "kind": "group"}, "android": {"url": "https://qm.qq.com/q/ptPGw0wcEw", "name": "安卓版MAA 交流3群", "gid": "764534097", "kind": "group"}, "mac": {"url": "https://qm.qq.com/q/2uhPXiNOR0", "name": "Mac版MAA 交流群", "gid": "1091086083", "kind": "group"}};
         const CHANNELS = {"windows": {"url": "https://pd.qq.com/s/8d3h265zd?b=9", "name": "MAA QQ 频道"}, "android": {"url": "https://pd.qq.com/s/4w4kgi4s4", "name": "安卓版 MAA QQ 频道"}, "mac": null};
         const PLATFORM_LABELS = { windows: "Windows", android: "Android", mac: "Mac" };
         // 对外 groupinfo API（头像 + 人数）；失败则不展示
@@ -786,8 +786,8 @@
             </h3>
             <ul class="group-list">
                 <li class="group-item" data-platform="android" data-gid="1074855131" data-label="安卓版MAA 交流1群 (1074855131)" data-href="https://qm.qq.com/q/L8Tyfs268E"><a class="group-link" href="https://qm.qq.com/q/L8Tyfs268E" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流1群 (1074855131)</span><span class="group-meta" hidden></span></div></div></a></li>
-<li class="group-item" data-platform="android" data-gid="1092878305" data-label="安卓版MAA 交流2群 (1092878305)" data-href="https://qm.qq.com/q/hWvDx6cNag" data-recommend="1"><a class="group-link" href="https://qm.qq.com/q/hWvDx6cNag" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流2群 (1092878305)</span><span class="group-meta" hidden></span></div></div></a></li>
-<li class="group-item" data-platform="android" data-gid="764534097" data-label="安卓版MAA 交流3群 (764534097)" data-href="https://qm.qq.com/q/ptPGw0wcEw"><a class="group-link" href="https://qm.qq.com/q/ptPGw0wcEw" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流3群 (764534097)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="android" data-gid="1092878305" data-label="安卓版MAA 交流2群 (1092878305)" data-href="https://qm.qq.com/q/hWvDx6cNag"><a class="group-link" href="https://qm.qq.com/q/hWvDx6cNag" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流2群 (1092878305)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="android" data-gid="764534097" data-label="安卓版MAA 交流3群 (764534097)" data-href="https://qm.qq.com/q/ptPGw0wcEw" data-recommend="1"><a class="group-link" href="https://qm.qq.com/q/ptPGw0wcEw" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流3群 (764534097)</span><span class="group-meta" hidden></span></div></div></a></li>
             </ul>
         </section>
 

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -647,9 +647,54 @@
             ).forEach(applyChannelRecommendMark);
         }
 
-        function selectPlatform(platform) {
+        function normalizePlatform(raw) {
+            if (!raw) return "";
+            const s = String(raw).trim().toLowerCase();
+            const map = {
+                windows: "windows", win: "windows", win32: "windows", pc: "windows",
+                android: "android", and: "android",
+                mac: "mac", macos: "mac", osx: "mac", darwin: "mac",
+            };
+            return map[s] || "";
+        }
+
+        function platformFromUrl() {
+            try {
+                const params = new URLSearchParams(window.location.search);
+                const keys = ["platform", "os", "p", "client"];
+                for (let i = 0; i < keys.length; i++) {
+                    const v = normalizePlatform(params.get(keys[i]));
+                    if (v && RECOMMENDS[v]) return v;
+                }
+                // 兼容 #windows / #mac / #platform=android
+                const hash = (window.location.hash || "").replace(/^#/, "");
+                if (hash) {
+                    let h = hash;
+                    const eq = hash.indexOf("=");
+                    if (eq >= 0) h = hash.slice(eq + 1);
+                    const v = normalizePlatform(h);
+                    if (v && RECOMMENDS[v]) return v;
+                }
+            } catch (e) {}
+            return "";
+        }
+
+        function syncPlatformToUrl(platform) {
+            try {
+                const url = new URL(window.location.href);
+                url.searchParams.set("platform", platform);
+                ["os", "p", "client"].forEach((k) => url.searchParams.delete(k));
+                const next = url.pathname + url.search + (url.hash || "");
+                if (next !== window.location.pathname + window.location.search + window.location.hash) {
+                    history.replaceState(null, "", next);
+                }
+            } catch (e) {}
+        }
+
+        function selectPlatform(platform, options) {
             const rec = RECOMMENDS[platform];
             if (!rec) return;
+            options = options || {};
 
             // 主动点选平台视为新意图：重新开启自动跳转
             userCancelled = false;
@@ -689,7 +734,22 @@
             primary.href = rec.url;
             primary.classList.remove("is-disabled");
             primary.setAttribute("aria-disabled", "false");
+            if (!options.skipUrlSync) {
+                syncPlatformToUrl(platform);
+            }
             startRedirect(rec.url);
+        }
+
+        // URL 带平台时自动选中，无需手动点
+        // 例: ?platform=windows  ?os=android  ?p=mac  #windows
+        function initPlatformFromUrl() {
+            const p = platformFromUrl();
+            if (p) selectPlatform(p, { skipUrlSync: true });
+        }
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", initPlatformFromUrl);
+        } else {
+            initPlatformFromUrl();
         }
     </script>
 </head>
@@ -714,7 +774,7 @@
                         onclick="selectPlatform('mac')">Mac</button>
                 </div>
             </div>
-            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。</p>
+            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。也可通过链接指定，例如 <code>?platform=windows</code>。</p>
 
             <p>
                 <a id="primaryLink" href="#" class="primary-link chroma is-disabled"

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -324,7 +324,7 @@
             userCancelled = true;
             stopCountdown();
             const text = document.getElementById("redirectText");
-            if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+            if (text) text.textContent = "自动跳转已取消，可点击上方按钮或下方群链接加入";
         }
 
         function handleLinkClick(event) {
@@ -346,7 +346,7 @@
                 // 用户已取消过：只更新链接，不再自动跳
                 currentJoinUrl = url;
                 const text = document.getElementById("redirectText");
-                if (text) text.innerHTML = "自动跳转已取消，可点击上方按钮或下方群链接加入";
+                if (text) text.textContent = "自动跳转已取消，可点击上方按钮或下方群链接加入";
                 return;
             }
             currentJoinUrl = url;
@@ -354,9 +354,23 @@
             countdown = 8;
             if (countdownTimer) clearTimeout(countdownTimer);
 
-            document.getElementById("redirectText").innerHTML =
-                '已选择平台，页面将在 <span id="countdown">' + countdown + '</span> 秒后自动跳转……' +
-                '<button type="button" id="cancelBtn" class="cancel-btn" onclick="cancelRedirect()">取消自动跳转</button>';
+            const text = document.getElementById("redirectText");
+            if (text) {
+                text.replaceChildren();
+                text.appendChild(document.createTextNode("已选择平台，页面将在 "));
+                const cd = document.createElement("span");
+                cd.id = "countdown";
+                cd.textContent = String(countdown);
+                text.appendChild(cd);
+                text.appendChild(document.createTextNode(" 秒后自动跳转……"));
+                const cancelBtn = document.createElement("button");
+                cancelBtn.type = "button";
+                cancelBtn.id = "cancelBtn";
+                cancelBtn.className = "cancel-btn";
+                cancelBtn.textContent = "取消自动跳转";
+                cancelBtn.addEventListener("click", cancelRedirect);
+                text.appendChild(cancelBtn);
+            }
             countdownTimer = setTimeout(updateCountdown, 1000);
         }
 
@@ -371,15 +385,30 @@
             }
         }
 
-        function formatMembers(info) {
-            if (!info || !info.known) return "";
+        function renderMembersInto(el, info) {
+            // 用 DOM API 写人数，避免 innerHTML + 外部字段触发 XSS 告警
+            if (!el) return false;
+            el.replaceChildren();
+            if (!info || !info.known) {
+                el.hidden = true;
+                return false;
+            }
             const cur = info.member_count;
             const max = info.max_member_count;
-            if (!max || max <= 0) return "";
-            const free = typeof info.free_slots === "number" ? info.free_slots : Math.max(0, max - cur);
-            const cls = free <= 0 ? "full" : "ok";
+            if (!max || max <= 0) {
+                el.hidden = true;
+                return false;
+            }
+            const free = typeof info.free_slots === "number"
+                ? info.free_slots
+                : Math.max(0, max - cur);
+            const span = document.createElement("span");
+            span.className = free <= 0 ? "full" : "ok";
             const freeText = free <= 0 ? "已满" : ("余 " + free);
-            return '<span class="' + cls + '">' + cur + " / " + max + " · " + freeText + "</span>";
+            span.textContent = cur + " / " + max + " · " + freeText;
+            el.appendChild(span);
+            el.hidden = false;
+            return true;
         }
 
         function applyInfoToItem(li, info) {
@@ -392,7 +421,7 @@
                 }
                 if (meta) {
                     meta.hidden = true;
-                    meta.innerHTML = "";
+                    meta.replaceChildren();
                 }
                 return;
             }
@@ -403,16 +432,7 @@
             } else if (avatar) {
                 avatar.hidden = true;
             }
-            const html = formatMembers(info);
-            if (meta) {
-                if (html) {
-                    meta.innerHTML = html;
-                    meta.hidden = false;
-                } else {
-                    meta.hidden = true;
-                    meta.innerHTML = "";
-                }
-            }
+            renderMembersInto(meta, info);
         }
 
         function clearHeaderRecExtra() {
@@ -426,7 +446,7 @@
             }
             if (members) {
                 members.hidden = true;
-                members.innerHTML = "";
+                members.replaceChildren();
             }
         }
 
@@ -447,14 +467,8 @@
             } else if (img) {
                 img.hidden = true;
             }
-            const html = formatMembers(info);
-            if (members && html) {
-                members.innerHTML = html;
-                members.hidden = false;
+            if (renderMembersInto(members, info)) {
                 show = true;
-            } else if (members) {
-                members.hidden = true;
-                members.innerHTML = "";
             }
             row.classList.toggle("is-visible", show);
         }
@@ -587,8 +601,13 @@
                 const href = li.getAttribute("data-href");
                 const label = li.getAttribute("data-label") || "";
                 if (!href) return;
-                li.innerHTML = '<a href="' + href + '" onclick="handleLinkClick(event)">' +
-                    label + "</a>";
+                // 用 createElement，避免 DOM 属性拼进 innerHTML（CodeQL: DOM text reinterpreted as HTML）
+                li.replaceChildren();
+                const a = document.createElement("a");
+                a.setAttribute("href", href);
+                a.textContent = label;
+                a.addEventListener("click", handleLinkClick);
+                li.appendChild(a);
             });
         }
 
@@ -605,8 +624,13 @@
         function applyChannelRecommendMark(li) {
             li.classList.add("is-recommend");
             const label = li.getAttribute("data-label") || "";
-            li.innerHTML = '<strong><span class="current">' + label +
-                " - 当前推荐</span></strong>";
+            li.replaceChildren();
+            const strong = document.createElement("strong");
+            const span = document.createElement("span");
+            span.className = "current";
+            span.textContent = label + " - 当前推荐";
+            strong.appendChild(span);
+            li.appendChild(strong);
         }
 
         function markPlatformRecommend(platform) {
@@ -724,7 +748,11 @@
                 title.textContent = "欢迎加入【" + rec.name + "】（" + label + "）";
                 if (rec.gid) {
                     gidEl.style.display = "";
-                    gidEl.innerHTML = '群号: <strong>' + rec.gid + "</strong>";
+                    gidEl.replaceChildren();
+                    gidEl.appendChild(document.createTextNode("群号: "));
+                    const strong = document.createElement("strong");
+                    strong.textContent = String(rec.gid);
+                    gidEl.appendChild(strong);
                 } else {
                     gidEl.style.display = "none";
                 }

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -334,11 +334,11 @@
         const RECOMMENDS = {"windows": {"url": "https://qm.qq.com/q/SZilizX7SW", "name": "MAA 二十八裙", "gid": "739772723", "kind": "group"}, "android": {"url": "https://qm.qq.com/q/ptPGw0wcEw", "name": "安卓版MAA 交流3群", "gid": "764534097", "kind": "group"}, "mac": {"url": "https://qm.qq.com/q/2uhPXiNOR0", "name": "Mac版MAA 交流群", "gid": "1091086083", "kind": "group"}};
         const CHANNELS = {"windows": {"url": "https://pd.qq.com/s/8d3h265zd?b=9", "name": "MAA QQ 频道"}, "android": {"url": "https://pd.qq.com/s/4w4kgi4s4", "name": "安卓版 MAA QQ 频道"}, "mac": null};
         const PLATFORM_LABELS = { windows: "Windows", android: "Android", mac: "Mac" };
-        // 对外 groupinfo API（头像 + 人数）；失败则不展示
+        // 与 gen_index.py 同一 GROUPINFO_API（可由环境变量覆盖后注入）
         const GROUPINFO_API = "https://join.maameow.com/api/groupinfo";
         const groupInfoCache = Object.create(null); // gid -> info | null(failed)
 
-        // 必须用户主动选择平台后，才启动自动跳转
+        // 未选平台不自动跳转；URL/?platform= 指定时等同已选并启动跳转
         let redirectEnabled = false;
         let countdown = 8;
         let countdownTimer = null;
@@ -822,7 +822,7 @@
 
             <div class="platform-row">
                 <span class="platform-label">请先选择平台：</span>
-                <div class="platform-tabs" role="tablist" aria-label="客户端平台">
+                <div class="platform-tabs" role="group" aria-label="客户端平台">
                     <button type="button" class="platform-tab" data-platform="windows"
                         onclick="selectPlatform('windows')">Windows</button>
                     <button type="button" class="platform-tab" data-platform="android"

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -228,6 +228,67 @@
             background: #fff4e8;
             border-left: 4px solid #ff6600;
         }
+        .group-link {
+            display: block;
+            color: inherit;
+            text-decoration: none;
+            font-weight: normal;
+        }
+        .group-link:hover { text-decoration: none; }
+        .group-link:hover .group-title { text-decoration: underline; color: #004499; }
+        .group-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+        .group-avatar {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            object-fit: cover;
+            flex-shrink: 0;
+            background: #e8eef8;
+        }
+        .group-body {
+            min-width: 0;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+        .group-title {
+            font-weight: bold;
+            color: #0066cc;
+            word-break: break-all;
+        }
+        .group-item.is-recommend .group-title { color: #ff6600; }
+        .group-meta {
+            color: #666;
+            font-size: 0.9em;
+        }
+        .group-meta .full { color: #cc4444; }
+        .group-meta .ok { color: #2a7a2a; }
+        .disabled-row .group-title { color: #999; font-weight: normal; }
+        .header-rec-row {
+            display: none;
+            align-items: center;
+            gap: 12px;
+            margin: 8px 0 4px;
+        }
+        .header-rec-row.is-visible { display: flex; }
+        .header-avatar {
+            width: 48px;
+            height: 48px;
+            border-radius: 10px;
+            object-fit: cover;
+            background: #e8eef8;
+            flex-shrink: 0;
+        }
+        .header-members {
+            margin: 0;
+            color: #555;
+            font-size: 0.95em;
+        }
         .lists-heading { margin: 24px 0 8px; font-size: 1.15em; }
         .lists-placeholder { color: #888; margin: 12px 0 24px; }
         .lists-placeholder.is-hidden { display: none; }
@@ -239,6 +300,9 @@
         const RECOMMENDS = {"windows": {"url": "https://qm.qq.com/q/SZilizX7SW", "name": "MAA 二十八裙", "gid": "739772723", "kind": "group"}, "android": {"url": "https://qm.qq.com/q/hWvDx6cNag", "name": "安卓版MAA 交流2群", "gid": "1092878305", "kind": "group"}, "mac": {"url": "https://qm.qq.com/q/2uhPXiNOR0", "name": "Mac版MAA 交流群", "gid": "1091086083", "kind": "group"}};
         const CHANNELS = {"windows": {"url": "https://pd.qq.com/s/8d3h265zd?b=9", "name": "MAA QQ 频道"}, "android": {"url": "https://pd.qq.com/s/4w4kgi4s4", "name": "安卓版 MAA QQ 频道"}, "mac": null};
         const PLATFORM_LABELS = { windows: "Windows", android: "Android", mac: "Mac" };
+        // 对外 groupinfo API（头像 + 人数）；失败则不展示
+        const GROUPINFO_API = "https://join.maameow.com/api/groupinfo";
+        const groupInfoCache = Object.create(null); // gid -> info | null(failed)
 
         // 必须用户主动选择平台后，才启动自动跳转
         let redirectEnabled = false;
@@ -307,8 +371,217 @@
             }
         }
 
-        function resetListRecommendMarks(selector) {
-            document.querySelectorAll(selector).forEach((li) => {
+        function formatMembers(info) {
+            if (!info || !info.known) return "";
+            const cur = info.member_count;
+            const max = info.max_member_count;
+            if (!max || max <= 0) return "";
+            const free = typeof info.free_slots === "number" ? info.free_slots : Math.max(0, max - cur);
+            const cls = free <= 0 ? "full" : "ok";
+            const freeText = free <= 0 ? "已满" : ("余 " + free);
+            return '<span class="' + cls + '">' + cur + " / " + max + " · " + freeText + "</span>";
+        }
+
+        function applyInfoToItem(li, info) {
+            const avatar = li.querySelector(".group-avatar");
+            const meta = li.querySelector(".group-meta");
+            if (!info || !info.known) {
+                if (avatar) {
+                    avatar.hidden = true;
+                    avatar.removeAttribute("src");
+                }
+                if (meta) {
+                    meta.hidden = true;
+                    meta.innerHTML = "";
+                }
+                return;
+            }
+            if (avatar && info.avatar_url) {
+                avatar.src = info.avatar_url;
+                avatar.alt = (info.group_name || "") + " 头像";
+                avatar.hidden = false;
+            } else if (avatar) {
+                avatar.hidden = true;
+            }
+            const html = formatMembers(info);
+            if (meta) {
+                if (html) {
+                    meta.innerHTML = html;
+                    meta.hidden = false;
+                } else {
+                    meta.hidden = true;
+                    meta.innerHTML = "";
+                }
+            }
+        }
+
+        function clearHeaderRecExtra() {
+            const row = document.getElementById("headerRecRow");
+            const img = document.getElementById("headerAvatar");
+            const members = document.getElementById("headerMembers");
+            if (row) row.classList.remove("is-visible");
+            if (img) {
+                img.hidden = true;
+                img.removeAttribute("src");
+            }
+            if (members) {
+                members.hidden = true;
+                members.innerHTML = "";
+            }
+        }
+
+        function applyHeaderRecExtra(info) {
+            const row = document.getElementById("headerRecRow");
+            const img = document.getElementById("headerAvatar");
+            const members = document.getElementById("headerMembers");
+            if (!row || !info || !info.known) {
+                clearHeaderRecExtra();
+                return;
+            }
+            let show = false;
+            if (img && info.avatar_url) {
+                img.src = info.avatar_url;
+                img.alt = (info.group_name || "推荐群") + " 头像";
+                img.hidden = false;
+                show = true;
+            } else if (img) {
+                img.hidden = true;
+            }
+            const html = formatMembers(info);
+            if (members && html) {
+                members.innerHTML = html;
+                members.hidden = false;
+                show = true;
+            } else if (members) {
+                members.hidden = true;
+                members.innerHTML = "";
+            }
+            row.classList.toggle("is-visible", show);
+        }
+
+        function chunk(arr, size) {
+            const out = [];
+            for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+            return out;
+        }
+
+        function applyPlatformInfoForIds(platform, ids, recGid) {
+            // 只刷新本批相关 DOM，有结果就先展示
+            ids.forEach((id) => {
+                if (!(id in groupInfoCache)) return;
+                document.querySelectorAll(
+                    '.group-item[data-platform="' + platform + '"][data-gid="' + id + '"]'
+                ).forEach((li) => {
+                    applyInfoToItem(li, groupInfoCache[id]);
+                });
+            });
+            if (recGid && (recGid in groupInfoCache)) {
+                applyHeaderRecExtra(groupInfoCache[recGid]);
+            }
+        }
+
+        async function fetchGroupInfoBatch(ids, onPartDone) {
+            const missing = ids.filter((id) => !(id in groupInfoCache));
+            // 已有缓存的也回调，方便立刻上屏
+            const already = ids.filter((id) => id in groupInfoCache);
+            if (already.length && typeof onPartDone === "function") {
+                onPartDone(already);
+            }
+            if (!missing.length) return;
+
+            // 小批量串行；每批返回立刻 onPartDone，不用等全部
+            for (const part of chunk(missing, 5)) {
+                try {
+                    const url = GROUPINFO_API + "?ids=" + encodeURIComponent(part.join(","));
+                    const resp = await fetch(url, {
+                        method: "GET",
+                        mode: "cors",
+                        credentials: "omit",
+                        cache: "default",
+                    });
+                    if (!resp.ok) {
+                        part.forEach((id) => { groupInfoCache[id] = null; });
+                        if (typeof onPartDone === "function") onPartDone(part);
+                        continue;
+                    }
+                    const body = await resp.json();
+                    if (!body || body.code !== 0 || !body.data) {
+                        part.forEach((id) => { groupInfoCache[id] = null; });
+                        if (typeof onPartDone === "function") onPartDone(part);
+                        continue;
+                    }
+                    const list = Array.isArray(body.data.groups)
+                        ? body.data.groups
+                        : (body.data.group_id ? [body.data] : []);
+                    const byId = Object.create(null);
+                    list.forEach((g) => {
+                        if (g && g.group_id) byId[String(g.group_id)] = g;
+                    });
+                    part.forEach((id) => {
+                        const g = byId[id];
+                        groupInfoCache[id] = (g && g.known) ? g : null;
+                    });
+                } catch (e) {
+                    part.forEach((id) => { groupInfoCache[id] = null; });
+                }
+                if (typeof onPartDone === "function") onPartDone(part);
+            }
+        }
+
+        async function loadPlatformGroupInfo(platform) {
+            const items = document.querySelectorAll(
+                '.group-item[data-platform="' + platform + '"][data-gid]'
+            );
+            const ids = [];
+            items.forEach((li) => {
+                const gid = li.getAttribute("data-gid");
+                if (gid) ids.push(gid);
+            });
+            // 推荐群也查一下（可能与列表同一 gid）
+            const rec = RECOMMENDS[platform];
+            let recGid = "";
+            if (rec && rec.kind !== "channel" && rec.gid) {
+                recGid = String(rec.gid);
+                ids.push(recGid);
+            } else {
+                clearHeaderRecExtra();
+            }
+            // 推荐群优先拉取，顶部头像/人数更早出现
+            let unique = Array.from(new Set(ids));
+            if (recGid) {
+                unique = [recGid].concat(unique.filter((id) => id !== recGid));
+            }
+            if (!unique.length) {
+                clearHeaderRecExtra();
+                return;
+            }
+            // 已缓存的立刻上屏
+            const cachedNow = unique.filter((id) => id in groupInfoCache);
+            if (cachedNow.length) {
+                applyPlatformInfoForIds(platform, cachedNow, recGid);
+            }
+            // 逐批回调：哪批好了就先画哪批
+            await fetchGroupInfoBatch(unique, (partIds) => {
+                // 平台已切换则丢弃过期回调
+                if (currentPlatform !== platform) return;
+                applyPlatformInfoForIds(platform, partIds, recGid);
+            });
+        }
+
+        function resetGroupRecommendMarks() {
+            document.querySelectorAll(".group-item").forEach((li) => {
+                li.classList.remove("is-recommend");
+                const title = li.querySelector(".group-title");
+                if (!title) return;
+                const label = li.getAttribute("data-label") || "";
+                // 去掉「 - 当前推荐」后缀
+                title.textContent = label;
+                title.classList.remove("current");
+            });
+        }
+
+        function resetChannelRecommendMarks() {
+            document.querySelectorAll(".channel-item").forEach((li) => {
                 li.classList.remove("is-recommend");
                 if (li.querySelector(".disabled")) return;
                 const href = li.getAttribute("data-href");
@@ -319,7 +592,17 @@
             });
         }
 
-        function applyRecommendMark(li) {
+        function applyGroupRecommendMark(li) {
+            li.classList.add("is-recommend");
+            const title = li.querySelector(".group-title");
+            const label = li.getAttribute("data-label") || "";
+            if (title) {
+                title.textContent = label + " - 当前推荐";
+                title.classList.add("current");
+            }
+        }
+
+        function applyChannelRecommendMark(li) {
             li.classList.add("is-recommend");
             const label = li.getAttribute("data-label") || "";
             li.innerHTML = '<strong><span class="current">' + label +
@@ -327,8 +610,8 @@
         }
 
         function markPlatformRecommend(platform) {
-            resetListRecommendMarks(".group-item");
-            resetListRecommendMarks(".channel-item");
+            resetGroupRecommendMarks();
+            resetChannelRecommendMarks();
 
             const listsPlaceholder = document.getElementById("listsPlaceholder");
             if (listsPlaceholder) listsPlaceholder.classList.add("is-hidden");
@@ -356,13 +639,12 @@
                 channelBlock.classList.toggle("is-empty", !hasChannel);
             }
 
-            // 高亮当前推荐（群或频道）
             document.querySelectorAll(
                 '.group-item[data-platform="' + platform + '"][data-recommend="1"]'
-            ).forEach(applyRecommendMark);
+            ).forEach(applyGroupRecommendMark);
             document.querySelectorAll(
                 '.channel-item[data-platform="' + platform + '"][data-recommend="1"]'
-            ).forEach(applyRecommendMark);
+            ).forEach(applyChannelRecommendMark);
         }
 
         function selectPlatform(platform) {
@@ -378,6 +660,9 @@
             });
 
             markPlatformRecommend(platform);
+            clearHeaderRecExtra();
+            // 异步拉头像/人数；失败静默，不展示
+            loadPlatformGroupInfo(platform);
 
             const title = document.getElementById("join-title");
             const gidEl = document.getElementById("join-gid");
@@ -412,6 +697,10 @@
     <div class="container">
         <div id="join-header" class="header">
             <h2 id="join-title">欢迎加入 MAA 交流群</h2>
+            <div id="headerRecRow" class="header-rec-row">
+                <img id="headerAvatar" class="header-avatar" alt="" width="48" height="48" hidden>
+                <p id="headerMembers" class="header-members" hidden></p>
+            </div>
             <p id="join-gid" style="display:none"></p>
 
             <div class="platform-row">
@@ -453,41 +742,41 @@
                 <span class="group-count">共 35 个</span>
             </h3>
             <ul class="group-list">
-                <li class="group-item" data-platform="windows" data-label="MAA 一裙 (791704225)" data-href="https://qm.qq.com/q/brtJGf5h2o"><a href="https://qm.qq.com/q/brtJGf5h2o" onclick="handleLinkClick(event)">MAA 一裙 (791704225)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 避难所 (875959402)" data-href="https://qm.qq.com/q/qLl7QgcxQ4"><a href="https://qm.qq.com/q/qLl7QgcxQ4" onclick="handleLinkClick(event)">MAA 避难所 (875959402)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 三裙 (954069034)" data-href="https://qm.qq.com/q/yo4UYi3SIS"><a href="https://qm.qq.com/q/yo4UYi3SIS" onclick="handleLinkClick(event)">MAA 三裙 (954069034)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 四裙 (645852443)" data-href="https://qm.qq.com/q/Xy1STSCJWK"><a href="https://qm.qq.com/q/Xy1STSCJWK" onclick="handleLinkClick(event)">MAA 四裙 (645852443)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 五裙 (399375745)" data-href="https://qm.qq.com/q/R3w7RQIZIy"><a href="https://qm.qq.com/q/R3w7RQIZIy" onclick="handleLinkClick(event)">MAA 五裙 (399375745)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 六裙 (704746719)" data-href="https://qm.qq.com/q/mDj4OY07mg"><a href="https://qm.qq.com/q/mDj4OY07mg" onclick="handleLinkClick(event)">MAA 六裙 (704746719)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 七裙 (285898225)" data-href="https://qm.qq.com/q/aK0SnYsWGc"><a href="https://qm.qq.com/q/aK0SnYsWGc" onclick="handleLinkClick(event)">MAA 七裙 (285898225)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 八裙 (290949547)" data-href="https://qm.qq.com/q/pNCuptVPhK"><a href="https://qm.qq.com/q/pNCuptVPhK" onclick="handleLinkClick(event)">MAA 八裙 (290949547)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 九裙 (764034517)" data-href="https://qm.qq.com/q/sDBm8wDowo"><a href="https://qm.qq.com/q/sDBm8wDowo" onclick="handleLinkClick(event)">MAA 九裙 (764034517)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十裙 (362529812)" data-href="https://qm.qq.com/q/ekeuIR4ZvU"><a href="https://qm.qq.com/q/ekeuIR4ZvU" onclick="handleLinkClick(event)">MAA 十裙 (362529812)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十一裙 (536038978)" data-href="https://qm.qq.com/q/hVjtFOkyeQ"><a href="https://qm.qq.com/q/hVjtFOkyeQ" onclick="handleLinkClick(event)">MAA 十一裙 (536038978)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十二裙 (577460690)" data-href="https://qm.qq.com/q/m7nBOkijOE"><a href="https://qm.qq.com/q/m7nBOkijOE" onclick="handleLinkClick(event)">MAA 十二裙 (577460690)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十三裙 (518779858)" data-href="https://qm.qq.com/q/k0KlwMhrpe"><a href="https://qm.qq.com/q/k0KlwMhrpe" onclick="handleLinkClick(event)">MAA 十三裙 (518779858)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十四裙 (1105335749)" data-href="https://qm.qq.com/q/Ehh5ouuopy"><a href="https://qm.qq.com/q/Ehh5ouuopy" onclick="handleLinkClick(event)">MAA 十四裙 (1105335749)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十五裙 (821474369)" data-href="https://qm.qq.com/q/dOy0JcI7ew"><a href="https://qm.qq.com/q/dOy0JcI7ew" onclick="handleLinkClick(event)">MAA 十五裙 (821474369)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十六裙 (756840093)" data-href="https://qm.qq.com/q/eVv3ZHFPPO"><a href="https://qm.qq.com/q/eVv3ZHFPPO" onclick="handleLinkClick(event)">MAA 十六裙 (756840093)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十七裙 (130793607)" data-href="https://qm.qq.com/q/WA16EHmPGc"><a href="https://qm.qq.com/q/WA16EHmPGc" onclick="handleLinkClick(event)">MAA 十七裙 (130793607)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十八裙 (1019089084)" data-href="https://qm.qq.com/q/HtWF3F9csu"><a href="https://qm.qq.com/q/HtWF3F9csu" onclick="handleLinkClick(event)">MAA 十八裙 (1019089084)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 十九裙 (1037746358)" data-href="https://qm.qq.com/q/VZziwrFio4"><a href="https://qm.qq.com/q/VZziwrFio4" onclick="handleLinkClick(event)">MAA 十九裙 (1037746358)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十裙 (811923437)" data-href="https://qm.qq.com/q/r8QSte9pf2"><a href="https://qm.qq.com/q/r8QSte9pf2" onclick="handleLinkClick(event)">MAA 二十裙 (811923437)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十一裙 (147682068)" data-href="https://qm.qq.com/q/Ly0mxKm9Cs"><a href="https://qm.qq.com/q/Ly0mxKm9Cs" onclick="handleLinkClick(event)">MAA 二十一裙 (147682068)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十二裙 (1018167389)" data-href="https://qm.qq.com/q/fxL5QSX53a"><a href="https://qm.qq.com/q/fxL5QSX53a" onclick="handleLinkClick(event)">MAA 二十二裙 (1018167389)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十三裙 (744379789)" data-href="https://qm.qq.com/q/wgwWha2QiA"><a href="https://qm.qq.com/q/wgwWha2QiA" onclick="handleLinkClick(event)">MAA 二十三裙 (744379789)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十四裙 (1017931295)" data-href="https://qm.qq.com/q/U6hTfcjxa8"><a href="https://qm.qq.com/q/U6hTfcjxa8" onclick="handleLinkClick(event)">MAA 二十四裙 (1017931295)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十五裙 (978314648)" data-href="https://qm.qq.com/q/MUeqpeXu8M"><a href="https://qm.qq.com/q/MUeqpeXu8M" onclick="handleLinkClick(event)">MAA 二十五裙 (978314648)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十六裙 (475886359)" data-href="https://qm.qq.com/q/34CZxNGeCc"><a href="https://qm.qq.com/q/34CZxNGeCc" onclick="handleLinkClick(event)">MAA 二十六裙 (475886359)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十七裙 (1037257260)" data-href="https://qm.qq.com/q/JebChwBSUu"><a href="https://qm.qq.com/q/JebChwBSUu" onclick="handleLinkClick(event)">MAA 二十七裙 (1037257260)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十八裙 (739772723)" data-href="https://qm.qq.com/q/SZilizX7SW" data-recommend="1"><a href="https://qm.qq.com/q/SZilizX7SW" onclick="handleLinkClick(event)">MAA 二十八裙 (739772723)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 二十九裙 (514134954)" data-href="https://qm.qq.com/q/YV1bCw5CKK"><a href="https://qm.qq.com/q/YV1bCw5CKK" onclick="handleLinkClick(event)">MAA 二十九裙 (514134954)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 三十裙 (596196146)" data-href="https://qm.qq.com/q/6EHIjpxUBy"><a href="https://qm.qq.com/q/6EHIjpxUBy" onclick="handleLinkClick(event)">MAA 三十裙 (596196146)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 三十一裙 (545928846)" data-href="https://qm.qq.com/q/sW8LlaNMME"><a href="https://qm.qq.com/q/sW8LlaNMME" onclick="handleLinkClick(event)">MAA 三十一裙 (545928846)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 三十二裙 (216314927)" data-href="https://qm.qq.com/q/pt47DXsH2E"><a href="https://qm.qq.com/q/pt47DXsH2E" onclick="handleLinkClick(event)">MAA 三十二裙 (216314927)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 三十三裙 (1003478193)" data-href="https://qm.qq.com/q/ZsMmM5IX2A"><a href="https://qm.qq.com/q/ZsMmM5IX2A" onclick="handleLinkClick(event)">MAA 三十三裙 (1003478193)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 三十四裙 (1009052305)" data-href="https://qm.qq.com/q/ImsUweGc8i"><a href="https://qm.qq.com/q/ImsUweGc8i" onclick="handleLinkClick(event)">MAA 三十四裙 (1009052305)</a></li>
-<li class="group-item" data-platform="windows" data-label="MAA 三十五裙 (774683898)" data-href="https://qm.qq.com/q/hfisRrMmnC"><a href="https://qm.qq.com/q/hfisRrMmnC" onclick="handleLinkClick(event)">MAA 三十五裙 (774683898)</a></li>
+                <li class="group-item" data-platform="windows" data-gid="791704225" data-label="MAA 一裙 (791704225)" data-href="https://qm.qq.com/q/brtJGf5h2o"><a class="group-link" href="https://qm.qq.com/q/brtJGf5h2o" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 一裙 (791704225)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="875959402" data-label="MAA 避难所 (875959402)" data-href="https://qm.qq.com/q/qLl7QgcxQ4"><a class="group-link" href="https://qm.qq.com/q/qLl7QgcxQ4" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 避难所 (875959402)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="954069034" data-label="MAA 三裙 (954069034)" data-href="https://qm.qq.com/q/yo4UYi3SIS"><a class="group-link" href="https://qm.qq.com/q/yo4UYi3SIS" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 三裙 (954069034)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="645852443" data-label="MAA 四裙 (645852443)" data-href="https://qm.qq.com/q/Xy1STSCJWK"><a class="group-link" href="https://qm.qq.com/q/Xy1STSCJWK" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 四裙 (645852443)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="399375745" data-label="MAA 五裙 (399375745)" data-href="https://qm.qq.com/q/R3w7RQIZIy"><a class="group-link" href="https://qm.qq.com/q/R3w7RQIZIy" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 五裙 (399375745)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="704746719" data-label="MAA 六裙 (704746719)" data-href="https://qm.qq.com/q/mDj4OY07mg"><a class="group-link" href="https://qm.qq.com/q/mDj4OY07mg" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 六裙 (704746719)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="285898225" data-label="MAA 七裙 (285898225)" data-href="https://qm.qq.com/q/aK0SnYsWGc"><a class="group-link" href="https://qm.qq.com/q/aK0SnYsWGc" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 七裙 (285898225)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="290949547" data-label="MAA 八裙 (290949547)" data-href="https://qm.qq.com/q/pNCuptVPhK"><a class="group-link" href="https://qm.qq.com/q/pNCuptVPhK" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 八裙 (290949547)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="764034517" data-label="MAA 九裙 (764034517)" data-href="https://qm.qq.com/q/sDBm8wDowo"><a class="group-link" href="https://qm.qq.com/q/sDBm8wDowo" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 九裙 (764034517)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="362529812" data-label="MAA 十裙 (362529812)" data-href="https://qm.qq.com/q/ekeuIR4ZvU"><a class="group-link" href="https://qm.qq.com/q/ekeuIR4ZvU" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十裙 (362529812)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="536038978" data-label="MAA 十一裙 (536038978)" data-href="https://qm.qq.com/q/hVjtFOkyeQ"><a class="group-link" href="https://qm.qq.com/q/hVjtFOkyeQ" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十一裙 (536038978)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="577460690" data-label="MAA 十二裙 (577460690)" data-href="https://qm.qq.com/q/m7nBOkijOE"><a class="group-link" href="https://qm.qq.com/q/m7nBOkijOE" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十二裙 (577460690)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="518779858" data-label="MAA 十三裙 (518779858)" data-href="https://qm.qq.com/q/k0KlwMhrpe"><a class="group-link" href="https://qm.qq.com/q/k0KlwMhrpe" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十三裙 (518779858)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1105335749" data-label="MAA 十四裙 (1105335749)" data-href="https://qm.qq.com/q/Ehh5ouuopy"><a class="group-link" href="https://qm.qq.com/q/Ehh5ouuopy" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十四裙 (1105335749)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="821474369" data-label="MAA 十五裙 (821474369)" data-href="https://qm.qq.com/q/dOy0JcI7ew"><a class="group-link" href="https://qm.qq.com/q/dOy0JcI7ew" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十五裙 (821474369)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="756840093" data-label="MAA 十六裙 (756840093)" data-href="https://qm.qq.com/q/eVv3ZHFPPO"><a class="group-link" href="https://qm.qq.com/q/eVv3ZHFPPO" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十六裙 (756840093)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="130793607" data-label="MAA 十七裙 (130793607)" data-href="https://qm.qq.com/q/WA16EHmPGc"><a class="group-link" href="https://qm.qq.com/q/WA16EHmPGc" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十七裙 (130793607)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1019089084" data-label="MAA 十八裙 (1019089084)" data-href="https://qm.qq.com/q/HtWF3F9csu"><a class="group-link" href="https://qm.qq.com/q/HtWF3F9csu" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十八裙 (1019089084)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1037746358" data-label="MAA 十九裙 (1037746358)" data-href="https://qm.qq.com/q/VZziwrFio4"><a class="group-link" href="https://qm.qq.com/q/VZziwrFio4" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 十九裙 (1037746358)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="811923437" data-label="MAA 二十裙 (811923437)" data-href="https://qm.qq.com/q/r8QSte9pf2"><a class="group-link" href="https://qm.qq.com/q/r8QSte9pf2" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十裙 (811923437)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="147682068" data-label="MAA 二十一裙 (147682068)" data-href="https://qm.qq.com/q/Ly0mxKm9Cs"><a class="group-link" href="https://qm.qq.com/q/Ly0mxKm9Cs" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十一裙 (147682068)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1018167389" data-label="MAA 二十二裙 (1018167389)" data-href="https://qm.qq.com/q/fxL5QSX53a"><a class="group-link" href="https://qm.qq.com/q/fxL5QSX53a" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十二裙 (1018167389)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="744379789" data-label="MAA 二十三裙 (744379789)" data-href="https://qm.qq.com/q/wgwWha2QiA"><a class="group-link" href="https://qm.qq.com/q/wgwWha2QiA" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十三裙 (744379789)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1017931295" data-label="MAA 二十四裙 (1017931295)" data-href="https://qm.qq.com/q/U6hTfcjxa8"><a class="group-link" href="https://qm.qq.com/q/U6hTfcjxa8" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十四裙 (1017931295)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="978314648" data-label="MAA 二十五裙 (978314648)" data-href="https://qm.qq.com/q/MUeqpeXu8M"><a class="group-link" href="https://qm.qq.com/q/MUeqpeXu8M" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十五裙 (978314648)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="475886359" data-label="MAA 二十六裙 (475886359)" data-href="https://qm.qq.com/q/34CZxNGeCc"><a class="group-link" href="https://qm.qq.com/q/34CZxNGeCc" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十六裙 (475886359)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1037257260" data-label="MAA 二十七裙 (1037257260)" data-href="https://qm.qq.com/q/JebChwBSUu"><a class="group-link" href="https://qm.qq.com/q/JebChwBSUu" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十七裙 (1037257260)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="739772723" data-label="MAA 二十八裙 (739772723)" data-href="https://qm.qq.com/q/SZilizX7SW" data-recommend="1"><a class="group-link" href="https://qm.qq.com/q/SZilizX7SW" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十八裙 (739772723)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="514134954" data-label="MAA 二十九裙 (514134954)" data-href="https://qm.qq.com/q/YV1bCw5CKK"><a class="group-link" href="https://qm.qq.com/q/YV1bCw5CKK" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 二十九裙 (514134954)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="596196146" data-label="MAA 三十裙 (596196146)" data-href="https://qm.qq.com/q/6EHIjpxUBy"><a class="group-link" href="https://qm.qq.com/q/6EHIjpxUBy" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 三十裙 (596196146)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="545928846" data-label="MAA 三十一裙 (545928846)" data-href="https://qm.qq.com/q/sW8LlaNMME"><a class="group-link" href="https://qm.qq.com/q/sW8LlaNMME" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 三十一裙 (545928846)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="216314927" data-label="MAA 三十二裙 (216314927)" data-href="https://qm.qq.com/q/pt47DXsH2E"><a class="group-link" href="https://qm.qq.com/q/pt47DXsH2E" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 三十二裙 (216314927)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1003478193" data-label="MAA 三十三裙 (1003478193)" data-href="https://qm.qq.com/q/ZsMmM5IX2A"><a class="group-link" href="https://qm.qq.com/q/ZsMmM5IX2A" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 三十三裙 (1003478193)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="1009052305" data-label="MAA 三十四裙 (1009052305)" data-href="https://qm.qq.com/q/ImsUweGc8i"><a class="group-link" href="https://qm.qq.com/q/ImsUweGc8i" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 三十四裙 (1009052305)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="windows" data-gid="774683898" data-label="MAA 三十五裙 (774683898)" data-href="https://qm.qq.com/q/hfisRrMmnC"><a class="group-link" href="https://qm.qq.com/q/hfisRrMmnC" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">MAA 三十五裙 (774683898)</span><span class="group-meta" hidden></span></div></div></a></li>
             </ul>
         </section>
 
@@ -496,9 +785,9 @@
                 <span class="group-count">共 3 个</span>
             </h3>
             <ul class="group-list">
-                <li class="group-item" data-platform="android" data-label="安卓版MAA 交流1群 (1074855131)" data-href="https://qm.qq.com/q/L8Tyfs268E"><a href="https://qm.qq.com/q/L8Tyfs268E" onclick="handleLinkClick(event)">安卓版MAA 交流1群 (1074855131)</a></li>
-<li class="group-item" data-platform="android" data-label="安卓版MAA 交流2群 (1092878305)" data-href="https://qm.qq.com/q/hWvDx6cNag" data-recommend="1"><a href="https://qm.qq.com/q/hWvDx6cNag" onclick="handleLinkClick(event)">安卓版MAA 交流2群 (1092878305)</a></li>
-<li class="group-item" data-platform="android" data-label="安卓版MAA 交流3群 (764534097)" data-href="https://qm.qq.com/q/ptPGw0wcEw"><a href="https://qm.qq.com/q/ptPGw0wcEw" onclick="handleLinkClick(event)">安卓版MAA 交流3群 (764534097)</a></li>
+                <li class="group-item" data-platform="android" data-gid="1074855131" data-label="安卓版MAA 交流1群 (1074855131)" data-href="https://qm.qq.com/q/L8Tyfs268E"><a class="group-link" href="https://qm.qq.com/q/L8Tyfs268E" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流1群 (1074855131)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="android" data-gid="1092878305" data-label="安卓版MAA 交流2群 (1092878305)" data-href="https://qm.qq.com/q/hWvDx6cNag" data-recommend="1"><a class="group-link" href="https://qm.qq.com/q/hWvDx6cNag" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流2群 (1092878305)</span><span class="group-meta" hidden></span></div></div></a></li>
+<li class="group-item" data-platform="android" data-gid="764534097" data-label="安卓版MAA 交流3群 (764534097)" data-href="https://qm.qq.com/q/ptPGw0wcEw"><a class="group-link" href="https://qm.qq.com/q/ptPGw0wcEw" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">安卓版MAA 交流3群 (764534097)</span><span class="group-meta" hidden></span></div></div></a></li>
             </ul>
         </section>
 
@@ -507,7 +796,7 @@
                 <span class="group-count">共 1 个</span>
             </h3>
             <ul class="group-list">
-                <li class="group-item" data-platform="mac" data-label="Mac版MAA 交流群 (1091086083)" data-href="https://qm.qq.com/q/2uhPXiNOR0" data-recommend="1"><a href="https://qm.qq.com/q/2uhPXiNOR0" onclick="handleLinkClick(event)">Mac版MAA 交流群 (1091086083)</a></li>
+                <li class="group-item" data-platform="mac" data-gid="1091086083" data-label="Mac版MAA 交流群 (1091086083)" data-href="https://qm.qq.com/q/2uhPXiNOR0" data-recommend="1"><a class="group-link" href="https://qm.qq.com/q/2uhPXiNOR0" onclick="handleLinkClick(event)"><div class="group-row"><img class="group-avatar" alt="" width="40" height="40" hidden><div class="group-body"><span class="group-title">Mac版MAA 交流群 (1091086083)</span><span class="group-meta" hidden></span></div></div></a></li>
             </ul>
         </section>
 

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -595,19 +595,15 @@
         }
 
         function resetChannelRecommendMarks() {
+            // 不重建 <a>、不写回 href（CodeQL 会把 getAttribute→setAttribute(href) 判为 DOM XSS）
+            // 静态 HTML 里已有安全的 <a href=...>，只恢复文案与样式
             document.querySelectorAll(".channel-item").forEach((li) => {
                 li.classList.remove("is-recommend");
-                if (li.querySelector(".disabled")) return;
-                const href = li.getAttribute("data-href");
+                const a = li.querySelector("a");
+                if (!a) return;
                 const label = li.getAttribute("data-label") || "";
-                if (!href) return;
-                // 用 createElement，避免 DOM 属性拼进 innerHTML（CodeQL: DOM text reinterpreted as HTML）
-                li.replaceChildren();
-                const a = document.createElement("a");
-                a.setAttribute("href", href);
                 a.textContent = label;
-                a.addEventListener("click", handleLinkClick);
-                li.appendChild(a);
+                a.classList.remove("current");
             });
         }
 
@@ -622,15 +618,14 @@
         }
 
         function applyChannelRecommendMark(li) {
+            // 保留原有 <a href>，只改 textContent，避免从 data-* 回写 URL
             li.classList.add("is-recommend");
+            const a = li.querySelector("a");
             const label = li.getAttribute("data-label") || "";
-            li.replaceChildren();
-            const strong = document.createElement("strong");
-            const span = document.createElement("span");
-            span.className = "current";
-            span.textContent = label + " - 当前推荐";
-            strong.appendChild(span);
-            li.appendChild(strong);
+            if (a) {
+                a.textContent = label + " - 当前推荐";
+                a.classList.add("current");
+            }
         }
 
         function markPlatformRecommend(platform) {

--- a/MaaAssistantArknights/api/qqgroup/index.html
+++ b/MaaAssistantArknights/api/qqgroup/index.html
@@ -78,6 +78,7 @@
         .primary-link .btn-text {
             position: relative;
             z-index: 2;
+            border-radius: 8px;
         }
         .primary-link.is-disabled {
             pointer-events: none;
@@ -93,9 +94,26 @@
         .primary-link.is-disabled.chroma::after {
             display: none;
         }
-        /* 无缝炫彩：色带重复两份，translateX 平移 50% 避免顿挫 */
+        /* 满幅流动炫彩（中等明度）；文字胶囊偏实，保证可读 */
         .primary-link.chroma:not(.is-disabled) {
-            background: transparent;
+            background: #2a2048;
+            color: #fff;
+            box-shadow: 0 4px 16px rgba(114, 46, 209, 0.3);
+        }
+        .primary-link.chroma:not(.is-disabled) .btn-text {
+            position: relative;
+            z-index: 2;
+            display: inline-block;
+            padding: 5px 14px;
+            border-radius: 8px;
+            background: rgba(16, 12, 32, 0.8);
+            box-shadow:
+                0 0 0 1px rgba(255, 255, 255, 0.14) inset,
+                0 2px 8px rgba(0, 0, 0, 0.22);
+            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+            letter-spacing: 0.02em;
+            -webkit-backdrop-filter: blur(6px);
+            backdrop-filter: blur(6px);
         }
         .primary-link.chroma:not(.is-disabled)::before {
             content: "";
@@ -105,6 +123,7 @@
             height: 100%;
             width: 200%;
             z-index: 0;
+            opacity: 0.88;
             background: linear-gradient(
                 90deg,
                 #ff4d4f, #fa8c16, #fadb14, #52c41a, #13c2c2, #1677ff, #722ed1, #eb2f96,
@@ -118,39 +137,47 @@
         .primary-link.chroma:not(.is-disabled)::after {
             content: "";
             position: absolute;
-            top: 0;
-            left: -40%;
-            width: 40%;
-            height: 100%;
+            inset: 0;
             z-index: 1;
-            background: linear-gradient(
-                100deg,
-                transparent 0%,
-                rgba(255, 255, 255, 0.15) 40%,
-                rgba(255, 255, 255, 0.45) 50%,
-                rgba(255, 255, 255, 0.15) 60%,
-                transparent 100%
-            );
-            animation: chroma-shine 2.5s linear infinite;
+            background:
+                linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.1) 100%),
+                linear-gradient(
+                    100deg,
+                    transparent 0%,
+                    transparent 40%,
+                    rgba(255, 255, 255, 0.2) 50%,
+                    transparent 60%,
+                    transparent 100%
+                );
+            background-size: 100% 100%, 42% 100%;
+            background-repeat: no-repeat, no-repeat;
+            background-position: 0 0, -42% 0;
+            animation: chroma-shine 2.8s linear infinite;
             pointer-events: none;
-            will-change: transform;
+            will-change: background-position;
         }
         .primary-link.chroma:not(.is-disabled):hover {
-            filter: brightness(1.05);
-            box-shadow: 0 6px 16px rgba(114, 46, 209, 0.35);
+            filter: brightness(1.05) saturate(1.04);
+            box-shadow: 0 6px 20px rgba(114, 46, 209, 0.38);
             text-decoration: none;
             color: #fff;
         }
+        .primary-link.chroma:not(.is-disabled):hover .btn-text {
+            background: rgba(16, 12, 32, 0.86);
+        }
         .primary-link.chroma:not(.is-disabled):active {
-            filter: brightness(0.98);
+            filter: brightness(0.97);
+        }
+        .primary-link.chroma:not(.is-disabled):active .btn-text {
+            background: rgba(16, 12, 32, 0.9);
         }
         @keyframes chroma-slide {
             from { transform: translateX(0); }
             to { transform: translateX(-50%); }
         }
         @keyframes chroma-shine {
-            from { transform: translateX(0); }
-            to { transform: translateX(350%); }
+            from { background-position: 0 0, -42% 0; }
+            to { background-position: 0 0, 142% 0; }
         }
         @media (prefers-reduced-motion: reduce) {
             .primary-link.chroma:not(.is-disabled)::before,
@@ -159,17 +186,25 @@
             }
             .primary-link.chroma:not(.is-disabled)::before {
                 width: 100%;
-                background: #0066cc;
+                opacity: 0.92;
+                background: linear-gradient(135deg, #1677ff 0%, #722ed1 55%, #eb2f96 100%);
                 transform: none;
             }
             .primary-link.chroma:not(.is-disabled)::after {
-                display: none;
+                background: linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.1) 100%);
+                animation: none;
             }
             .primary-link.chroma:not(.is-disabled) {
-                box-shadow: none;
+                box-shadow: 0 4px 12px rgba(114, 46, 209, 0.3);
             }
-            .channel-header .primary-link.chroma:not(.is-disabled)::before {
-                background: #7c4dff;
+            .primary-link.chroma:not(.is-disabled) .btn-text {
+                background: rgba(16, 12, 32, 0.8);
+                text-shadow: none;
+                -webkit-backdrop-filter: none;
+                backdrop-filter: none;
+            }
+            .header.channel-header .primary-link.chroma:not(.is-disabled)::before {
+                background: linear-gradient(135deg, #722ed1 0%, #b37feb 100%);
             }
         }
         .cancel-btn {
@@ -195,7 +230,6 @@
             border-left: 4px solid #7c4dff;
         }
         .tip { color: #666; font-size: 0.95em; }
-        .hint { color: #555; margin: 8px 0 0; }
         /* 下方群列表：按平台分块，默认隐藏，选中后只显示对应平台 */
         .group-section {
             display: none;
@@ -797,7 +831,6 @@
                         onclick="selectPlatform('mac')">Mac</button>
                 </div>
             </div>
-            <p class="hint">选择平台后才会开始自动跳转，并显示该平台群列表。也可通过链接指定，例如 <code>?platform=windows</code>。</p>
 
             <p>
                 <a id="primaryLink" href="#" class="primary-link chroma is-disabled"


### PR DESCRIPTION
Close #583

## Summary by Sourcery

重新设计 QQ 群落地页生成逻辑，以支持按平台推荐和自动群聊选择，并更新 CI 以使用新的多平台配置。

新功能：
- 为各平台（Windows、Android、Mac）引入独立的 QQ 群和频道配置文件，用于生成加入页面。
- 基于可配置的 groupinfo API 提供的群成员占用数据，增加 Android/Mac 平台的自动推荐群聊功能。
- 通过嵌入 JSON 向前端暴露平台相关的推荐信息和元数据，以支持页面的动态行为。
- 在加入页面上实现平台选择器 UI，用于驱动主要的加入目标，并高亮推荐的群聊/频道。

增强改进：
- 用结构更清晰的生成器替换之前的单模式 gen_index 脚本，使其能按平台同时支持群聊和频道推荐。
- 重新设计生成的 index.html 布局，使其具备响应式、平台感知能力，并在可用时展示群头像和成员数量。
- 移除过时的按平台生成的 index 文件，统一整合为单一的 index.html 输出。
- 优化 CI 提交信息，以体现 Windows 平台的手动推荐配置，而 Android/Mac 仍然保持自动选择。

CI：
- 更新 `update_qq_group_index` GitHub Actions 工作流，以传递 `GROUPINFO_API`，并统一术语，明确 Windows 仅支持手动选群，而 Android/Mac 为自动选群。

杂项：
- 将 `content_summary.txt` 重命名为 `content_windows.txt`，并新增 `content_android.txt`、`content_mac.txt` 和 `content_channels.txt`，用于 QQ 群/频道配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revamp QQ group landing page generation to support per-platform recommendations and automatic group selection, and update CI to use the new multi-platform configuration.

New Features:
- Introduce per-platform (Windows, Android, Mac) QQ group and channel configuration files for generating the join page.
- Add automatic Android/Mac group recommendation based on group occupancy data from a configurable groupinfo API.
- Expose platform-specific recommendations and metadata to the frontend via embedded JSON for dynamic behavior.
- Implement a platform selector UI on the join page that drives the primary join target and highlights recommended groups/channels.

Enhancements:
- Replace the previous single-mode gen_index script with a more structured generator that supports both group and channel recommendations per platform.
- Redesign the generated index.html layout to be responsive, platform-aware, and to show group avatars and member counts when available.
- Remove obsolete per-platform index files and consolidate to a single index.html output.
- Refine CI commit messages to reflect Windows-specific recommendation while Android/Mac remain auto-selected.

CI:
- Update the update_qq_group_index GitHub Actions workflow to pass GROUPINFO_API and align terminology with Windows-only manual group selection and Android/Mac auto selection.

Chores:
- Rename content_summary.txt to content_windows.txt and add separate content_android.txt, content_mac.txt, and content_channels.txt for QQ group/channel configuration.

</details>