### PR TITLE
chore: 繁中服「相見歡」復刻

### DIFF
--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -284,21 +284,21 @@
   },
   "txwy": {
     "sideStoryStage": {
-      "揭幕者們 復刻": {
+      "相見歡 復刻": {
         "MinimumRequired": "v6.0.1",
         "Activity": {
-          "Tip": "SideStory「揭幕者們」復刻",
-          "StageName": "揭幕者們 復刻",
-          "UtcStartTime": "2026/05/27 04:00:00",
-          "UtcExpireTime": "2026/06/06 03:59:59",
+          "Tip": "SideStory「相見歡」復刻",
+          "StageName": "相見歡 復刻",
+          "UtcStartTime": "2026/08/07 04:00:00",
+          "UtcExpireTime": "2026/08/17 03:59:59",
           "TimeZone": 8
         },
         "Stages": [
-          { "Display": "SSReopen-PV", "Value": "SSReopen-PV", "Drop": "代理1~10" },
-          { "Display": "PV-10", "Value": "PV-10", "Drop": "31053" },
-          { "Display": "PV-9", "Value": "PV-9", "Drop": "30103" },
-          { "Display": "PV-8", "Value": "PV-8", "Drop": "30083" },
-          { "Display": "PV-5", "Value": "PV-5", "Drop": "搓玉用" }
+          { "Display": "SSReopen-OR", "Value": "SSReopen-OR", "Drop": "代理 1~9" },
+          { "Display": "OR-9", "Value": "OR-9", "Drop": "31063" },
+          { "Display": "OR-8", "Value": "OR-8", "Drop": "31023" },
+          { "Display": "OR-7", "Value": "OR-7", "Drop": "30063" },
+          { "Display": "OR-5", "Value": "OR-5", "Drop": "搓玉用" }
         ]
       },
       "雅賽努斯復仇記": {


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

改進內容：
- 調整 StageActivityV2 的活動定義，以支援在繁體中文伺服器上重新舉辦「相見歡」活動。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust StageActivityV2 activity definitions to support the rerun of the "相見歡" event on the Traditional Chinese server.

</details>