### PR TITLE
chore: 补充安卓版MAA 交流4群 (1051890306)

### DIFF
--- a/MaaAssistantArknights/api/qqgroup/content_android.txt
+++ b/MaaAssistantArknights/api/qqgroup/content_android.txt
@@ -1,3 +1,4 @@
 https://qm.qq.com/q/L8Tyfs268E|安卓版MAA 交流1群|1074855131
 https://qm.qq.com/q/hWvDx6cNag|安卓版MAA 交流2群|1092878305
 https://qm.qq.com/q/ptPGw0wcEw|安卓版MAA 交流3群|764534097
+https://qm.qq.com/q/vLvz5gmixc|安卓版MAA 交流4群|1051890306


### PR DESCRIPTION
## 说明

安卓版 MAA 新开了交流 4 群（群号 1051890306），当前 qqgroup 列表中缺失，补充进去。

## 改动

- `content_android.txt`：新增一行 `https://qm.qq.com/q/vLvz5gmixc|安卓版MAA 交流4群|1051890306`

`index.html` 由 `update_qq_group_index` 工作流生成，无需随 PR 修改；合并后跑一次 `workflow_dispatch`（android / auto）即可带上 4 群。

> 注：交流 3 群 (764534097) 目前约 1996/2000，接近满员，满了之后粘性自动选群会顺延推荐 4 群。

## Summary by Sourcery

将新的 Android MAA 讨论群添加到 QQ 群列表中。

New Features:
- 将第四个 Android MAA QQ 讨论群添加到可加入的群列表中。

Enhancements:
- 重新生成 Android QQ 群索引，以包含新群并更新群数量，同时保留现有推荐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add the new Android MAA discussion group to the QQ group listings.

New Features:
- Add the fourth Android MAA QQ discussion group to the available group list.

Enhancements:
- Regenerate the Android QQ group index to include the new group and update the group count while preserving existing recommendations.

</details>