### PR TITLE
chore: Yostar SPA part 2

### DIFF
--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -129,7 +129,7 @@
         "TimeZone": 9
       },
       {
-        "MinimumRequired": "v6.9.0",
+        "MinimumRequired": "v6.17.0-beta.5",
         "DisplayKey": "MiniGame@SPA",
         "Display": "堅守協定：盟約 後期",
         "Value": "MiniGame@SPA@Begin",
@@ -205,7 +205,7 @@
         "TimeZone": 9
       },
       {
-        "MinimumRequired": "v6.9.0",
+        "MinimumRequired": "v6.17.0-beta.5",
         "DisplayKey": "MiniGame@SPA",
         "Display": "위수 협의: 맹약 후반",
         "Value": "MiniGame@SPA@Begin",
@@ -281,7 +281,7 @@
         "TimeZone": -7
       },
       {
-        "MinimumRequired": "v6.9.0",
+        "MinimumRequired": "v6.17.0-beta.5",
         "DisplayKey": "MiniGame@SPA",
         "Display": "Stronghold Protocol: Alliance Part 2",
         "Value": "MiniGame@SPA@Begin",

--- a/MaaAssistantArknights/api/gui/StageActivityV2.json
+++ b/MaaAssistantArknights/api/gui/StageActivityV2.json
@@ -131,11 +131,11 @@
       {
         "MinimumRequired": "v6.9.0",
         "DisplayKey": "MiniGame@SPA",
-        "Display": "堅守協定：盟約",
+        "Display": "堅守協定：盟約 後期",
         "Value": "MiniGame@SPA@Begin",
         "TipKey": "MiniGame@SPATip",
-        "UtcStartTime": "2026/04/28 16:00:00",
-        "UtcExpireTime": "2026/05/26 03:59:59",
+        "UtcStartTime": "2026/08/20 17:00:00",
+        "UtcExpireTime": "2026/10/01 03:59:59",
         "TimeZone": 9
       },
       {
@@ -207,11 +207,11 @@
       {
         "MinimumRequired": "v6.9.0",
         "DisplayKey": "MiniGame@SPA",
-        "Display": "위수 협의: 맹약",
+        "Display": "위수 협의: 맹약 후반",
         "Value": "MiniGame@SPA@Begin",
         "TipKey": "MiniGame@SPATip",
-        "UtcStartTime": "2026/04/28 16:00:00",
-        "UtcExpireTime": "2026/05/26 03:59:59",
+        "UtcStartTime": "2026/08/20 17:00:00",
+        "UtcExpireTime": "2026/10/01 03:59:59",
         "TimeZone": 9
       },
       {
@@ -283,11 +283,11 @@
       {
         "MinimumRequired": "v6.9.0",
         "DisplayKey": "MiniGame@SPA",
-        "Display": "Stronghold Protocol: Alliance",
+        "Display": "Stronghold Protocol: Alliance Part 2",
         "Value": "MiniGame@SPA@Begin",
         "TipKey": "MiniGame@SPATip",
-        "UtcStartTime": "2026/04/28 09:00:00",
-        "UtcExpireTime": "2026/05/26 03:59:59",
+        "UtcStartTime": "2026/08/20 09:00:00",
+        "UtcExpireTime": "2026/10/01 03:59:59",
         "TimeZone": -7
       },
       {


### PR DESCRIPTION
ref MaaAssistantArknights/MaaAssistantArknights@2010f0e76c5458c2a1de1fe6408fa5c744391e51

`MiniGame@SPA@GiveUp.png` needs to be added for part 2.

 Add `MiniGame@SPA@GiveUp.png`
- [x] EN
- [x] JP
- [x] KR
- [x] Bump `MinimumRequired` once released

## Summary by Sourcery

为第二次 Yostar SPA 发布更新舞台活动元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the stage activity metadata for the second Yostar SPA release.

</details>

## Summary by Sourcery

增强功能：
- 为第二次 Yostar SPA 版本更新阶段活动元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update stage activity metadata for the second Yostar SPA release.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强功能：
- 为第二次 Yostar SPA 版本更新阶段活动元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update stage activity metadata for the second Yostar SPA release.

</details>

</details>