### PR TITLE
chore: 調整繁中服「辭歲行」OCR 文字

### DIFF
--- a/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
+++ b/MaaAssistantArknights/api/resource/global/txwy/resource/tasks.json
@@ -6,6 +6,10 @@
         "next": ["FightSeries-CloseList"]
     },
     "TA-OpenOcr": {
+        "ocrReplace": [
+            ["^.春$", "望春"],		
+            ["潰事", "遺事"]
+		],
         "text": ["辭歲行", "望春", "遺事", "待筆", "新篇"]
     },
     "TAChapterToTA": {


### PR DESCRIPTION
OCR 又認錯字了 哭阿

## Sourcery 摘要

错误修复：
- 修正繁體中文伺服器「辭歲行」任务中错误的 OCR 文字。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct mistaken OCR text for the Traditional Chinese server's 「辭歲行」 task.

</details>